### PR TITLE
chore: harden runtime and release security

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,16 @@ __pycache__
 *.session-journal
 *.session-shm
 *.session-wal
+*.db
+*.db-journal
+*.db-shm
+*.db-wal
+*.sqlite
+*.sqlite3
+*.sqlite-journal
+*.sqlite-shm
+*.sqlite-wal
+.telefire
 logs
 dist
 build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,14 +12,16 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - run: uv build
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,20 @@ dmypy.json
 # Telethon session
 *.session
 *.session-journal
+*.session-shm
+*.session-wal
+
+# Local runtime state
+.telefire/
+*.db
+*.db-journal
+*.db-shm
+*.db-wal
+*.sqlite
+*.sqlite3
+*.sqlite-journal
+*.sqlite-shm
+*.sqlite-wal
 
 # Vim stuff
 *.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TELEFIRE=0.0.0 \
     SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc \
-    && groupadd --gid 10001 telefire \
+RUN groupadd --gid 10001 telefire \
     && useradd --uid 10001 --gid telefire --create-home --home-dir /home/telefire telefire \
     && mkdir -p /telefire-data \
-    && chown telefire:telefire /telefire-data \
-    && rm -rf /var/lib/apt/lists/*
+    && chown telefire:telefire /telefire-data
 
 WORKDIR /app
 COPY . /app

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,23 +1,16 @@
-FROM node:24-bookworm-slim
+FROM node:24-trixie-slim
 
 ENV NODE_ENV=production \
     HOME=/agent-data \
     PI_DATA_DIR=/agent-data/.pi-agent
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        bash \
-        ca-certificates \
-        curl \
-        git \
-        python3 \
-        ripgrep \
-    && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 COPY agent/package.json agent/package-lock.json ./
 RUN npm ci --omit=dev --ignore-scripts \
-    && npm cache clean --force
+    && npm cache clean --force \
+    && rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack \
+    && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+        /usr/local/bin/yarn /usr/local/bin/yarnpkg /usr/local/bin/pnpm /usr/local/bin/pnpx
 
 COPY agent/src ./src
 

--- a/src/telefire/ai.py
+++ b/src/telefire/ai.py
@@ -1436,7 +1436,7 @@ class AIStateRepository:
             batch = unique_ids[start : start + 500]
             placeholders = ",".join("?" for _ in batch)
             cursor = await connection.execute(
-                "SELECT document_id, content_hash, event_versions "
+                "SELECT document_id, content_hash, event_versions "  # nosec B608
                 "FROM ai_memory_documents WHERE scope_id = ? "
                 f"AND document_id IN ({placeholders})",
                 (scope_id, *batch),
@@ -1458,6 +1458,7 @@ class AIStateRepository:
         for start in range(0, len(unique_ids), 400):
             batch = unique_ids[start : start + 400]
             placeholders = ",".join("?" for _ in batch)
+            # Only the generated placeholder count is interpolated; values stay bound.
             query = f"""
                 SELECT document.document_id,
                        json_extract(event.value, '$[0]') AS source_id
@@ -1466,7 +1467,8 @@ class AIStateRepository:
                 WHERE document.scope_id = ?
                   AND json_extract(event.value, '$[0]') IN ({placeholders})
                 ORDER BY document.retained_at
-            """
+            """  # nosec B608
+            # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
             cursor = await connection.execute(
                 query,
                 (scope_id, *batch),
@@ -1833,7 +1835,7 @@ class AIStateRepository:
             batch = unique_ids[start : start + 500]
             placeholders = ",".join("?" for _ in batch)
             cursor = await connection.execute(
-                "SELECT message_id FROM ai_memory_excluded_messages "
+                "SELECT message_id FROM ai_memory_excluded_messages "  # nosec B608
                 f"WHERE chat_id = ? AND message_id IN ({placeholders})",
                 (chat_id, *batch),
             )
@@ -1853,7 +1855,7 @@ class AIStateRepository:
             batch = unique_ids[start : start + 500]
             placeholders = ",".join("?" for _ in batch)
             cursor = await connection.execute(
-                "SELECT answer_message_id FROM ai_answers "
+                "SELECT answer_message_id FROM ai_answers "  # nosec B608
                 f"WHERE chat_id = ? AND answer_message_id IN ({placeholders})",
                 (chat_id, *batch),
             )

--- a/src/telefire/plugins/__init__.py
+++ b/src/telefire/plugins/__init__.py
@@ -14,6 +14,8 @@ def load_plugins() -> None:
     for _, module_name, _ in pkgutil.iter_modules(__path__):
         if module_name.startswith("_") or module_name in _EXCLUDED_MODULES:
             continue
+        # Names come only from modules installed inside this package directory.
+        # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
         importlib.import_module(f"{__name__}.{module_name}")
 
     _LOADED = True

--- a/src/telefire/util/chengyu.py
+++ b/src/telefire/util/chengyu.py
@@ -1,16 +1,8 @@
-import pickle
 from collections import defaultdict
 
 
 def load_chengyu_dict():
     """Load chengyu dictionary from a list file and build character index"""
-    try:
-        # Try to load pre-built dictionary first
-        with open('chengyu_dict.pkl', 'rb') as f:
-            return pickle.load(f)
-    except FileNotFoundError:
-        pass
-    
     chengyu_dict = defaultdict(list)
     try:
         with open('chengyu_list.txt', 'r', encoding='utf-8') as f:
@@ -85,11 +77,4 @@ def load_chengyu_dict():
         first_char = chengyu[0]
         chengyu_dict[first_char].append(chengyu)
     
-    chengyu_dict = dict(chengyu_dict)
-    try:
-        with open('chengyu_dict.pkl', 'wb') as f:
-            pickle.dump(chengyu_dict, f)
-    except Exception as e:
-        print(f"Warning: Could not save chengyu dictionary: {e}")
-    
-    return chengyu_dict
+    return dict(chengyu_dict)

--- a/tests/test_chengyu.py
+++ b/tests/test_chengyu.py
@@ -1,0 +1,15 @@
+from telefire.util.chengyu import load_chengyu_dict
+
+
+def test_chengyu_loader_ignores_unsafe_pickle_cache(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "chengyu_dict.pkl").write_bytes(b"not a trusted pickle")
+    (tmp_path / "chengyu_list.txt").write_text(
+        "安居乐业\n业精于勤\n",
+        encoding="utf-8",
+    )
+
+    assert load_chengyu_dict() == {
+        "安": ["安居乐业"],
+        "业": ["业精于勤"],
+    }


### PR DESCRIPTION
## Summary
- remove unsafe working-directory pickle deserialization
- pin publishing actions and reduce workflow token persistence
- exclude runtime databases and session sidecars from Git and Docker contexts
- remove unnecessary compiler and agent shell toolchains from runtime images

## Security verification
- Gitleaks: 97 commits, 0 findings
- Trivy source scan: 0 secrets, 0 dependency vulnerabilities
- Semgrep: 0 findings after reviewed false-positive annotations
- Bandit: 0 medium/high findings
- Python: 197 passed, 5 skipped
- Agent: 42 passed
- Hardened image scans: 0 secrets and 0 fixable critical/high findings