### PR TITLE
chore: harden Hindsight runtime image

### DIFF
--- a/memory/Dockerfile.hindsight
+++ b/memory/Dockerfile.hindsight
@@ -1,0 +1,24 @@
+FROM ghcr.io/vectorize-io/hindsight:0.8.4@sha256:2c60f233eaba8f51db31adb920a560735aaf6f314e4b63c36c73159742dfa1a7
+
+USER root
+
+# Hindsight runs from its bundled virtualenv and invokes Node directly. Remove
+# package managers left by the upstream build and apply available OS fixes.
+RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
+    && rm -rf \
+        /app/sdk/node_modules/@hey-api/openapi-ts \
+        /usr/lib/node_modules/npm \
+        /usr/local/lib/python3.11/site-packages/* \
+        /var/lib/apt/lists/* \
+    && rm -f \
+        /usr/bin/npm \
+        /usr/bin/npx \
+        /usr/local/bin/pip \
+        /usr/local/bin/pip3 \
+        /usr/local/bin/pip3.11 \
+        /usr/local/bin/uv \
+        /usr/local/bin/uvx \
+        /usr/local/bin/wheel
+
+USER hindsight

--- a/memory/compose.yml
+++ b/memory/compose.yml
@@ -1,6 +1,9 @@
 services:
   memory-api:
-    image: ghcr.io/vectorize-io/hindsight:0.8.4@sha256:2c60f233eaba8f51db31adb920a560735aaf6f314e4b63c36c73159742dfa1a7
+    build:
+      context: .
+      dockerfile: Dockerfile.hindsight
+    image: telefire-hindsight:0.8.4-hardened
     container_name: memory-api
     environment:
       HINDSIGHT_API_LLM_PROVIDER: openai


### PR DESCRIPTION
## Summary
- derive the pinned Hindsight 0.8.4 image with current Debian security updates
- remove npm and global Python build tooling unused at runtime
- remove an unused OpenAPI generator copied into the runtime SDK

## Verification
- Hindsight API import: passed
- Control Plane startup and HTTP smoke test: passed
- Compose config validation: passed
- Trivy: 0 secrets, 0 fixable vulnerabilities
- Gitleaks: 98 commits, 0 findings