### PR TITLE
Show recalled memory in Agent Playground

### DIFF
--- a/agent/src/http-service.mjs
+++ b/agent/src/http-service.mjs
@@ -48,6 +48,7 @@ export function validateRunRequest(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const sessionId = value.sessionId;
   const parentEntryId = value.parentEntryId;
+  const includeMemorySnapshot = value.includeMemorySnapshot;
   const isRoot = sessionId === null && parentEntryId === null;
   const isContinuation =
     typeof sessionId === "string" &&
@@ -60,6 +61,10 @@ export function validateRunRequest(value) {
     !isBoundedString(value.prompt, 1, 16_000) ||
     !isBoundedString(value.systemPrompt, 1, 32_000) ||
     !new Set(["owner", "delegated", "none"]).has(value.toolPolicy) ||
+    !(
+      includeMemorySnapshot === undefined ||
+      typeof includeMemorySnapshot === "boolean"
+    ) ||
     !Array.isArray(value.context) ||
     value.context.length > 4
   ) {
@@ -134,6 +139,7 @@ export function validateRunRequest(value) {
     context,
     systemPrompt: value.systemPrompt,
     toolPolicy: value.toolPolicy,
+    ...(includeMemorySnapshot ? { includeMemorySnapshot: true } : {}),
     ...(memory ? { memory } : {}),
   };
 }

--- a/agent/src/pi-engine.mjs
+++ b/agent/src/pi-engine.mjs
@@ -383,6 +383,14 @@ export class PiEngine {
       timeoutMs: this.config.requestTimeoutMs,
       fetchImpl: this.config.memoryFetch,
     });
+    if (request.includeMemorySnapshot && request.memory) {
+      yield {
+        type: "memory_snapshot",
+        scopeId: request.memory.scopeId,
+        queries: recalled.queries,
+        memories: recalled.memories,
+      };
+    }
     const enrichedRequest = recalled.context
       ? {
           ...request,

--- a/agent/test/http-service.test.mjs
+++ b/agent/test/http-service.test.mjs
@@ -157,11 +157,26 @@ test("accepts a bounded memory target and rejects scope injection", async () => 
         ...validRun,
         context: [{ kind: "reference", text: "Alice joined the discussion." }],
         memory,
+        includeMemorySnapshot: true,
       }),
     });
     assert.equal(accepted.status, 200);
     await accepted.text();
     assert.deepEqual(received.memory, memory);
+    assert.equal(received.includeMemorySnapshot, true);
+
+    const rejectedSnapshotFlag = await fetch(`${app.baseUrl}/v1/runs`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-agent-token-that-is-long-enough",
+      },
+      body: JSON.stringify({
+        ...validRun,
+        includeMemorySnapshot: "yes",
+      }),
+    });
+    assert.equal(rejectedSnapshotFlag.status, 400);
 
     const rejected = await fetch(`${app.baseUrl}/v1/runs`, {
       method: "POST",

--- a/agent/test/pi-engine.test.mjs
+++ b/agent/test/pi-engine.test.mjs
@@ -235,9 +235,34 @@ test("owns initial memory retrieval and injects recalled evidence", async () => 
           scopeId: "workspace:engineering",
           anchors: [{ id: "person:alice", label: "Alice" }],
         },
+        includeMemorySnapshot: true,
       }),
     );
 
+    const memorySnapshot = events.find(
+      (event) => event.type === "memory_snapshot",
+    );
+    assert.deepEqual(memorySnapshot, {
+      type: "memory_snapshot",
+      scopeId: "workspace:engineering",
+      queries: [
+        "Current request: What did Richard say?\nReference context:\nA telecom discussion.",
+        "Current request: What did Richard say?\nReference context:\nA telecom discussion.\nIdentity anchors for resolving references: Alice (person:alice)",
+      ],
+      memories: [
+        {
+          id: "memory-1",
+          text: "Richard favors lower telecom prices.",
+          type: "world",
+          entities: ["Richard"],
+          occurredStart: null,
+          occurredEnd: null,
+          mentionedAt: null,
+          documentId: "conversation:7",
+          chunkId: "chunk-7",
+        },
+      ],
+    });
     assert.equal(events.at(-1).answer, "Richard favors lower prices.");
     assert.equal(recalls.length, 2);
     assert(recalls.some(({ body }) => body.query.includes("Identity anchors")));

--- a/playground/src/agent_playground/app.py
+++ b/playground/src/agent_playground/app.py
@@ -209,6 +209,7 @@ class PlaygroundData:
                 or "Automatic from request and references",
                 "memories": [],
                 "managedBy": "agent",
+                "status": "pending",
             }
         if request["context"]:
             context.append(
@@ -235,6 +236,7 @@ class PlaygroundData:
                 "scopeId": bank_id,
                 "anchors": [],
             }
+            pi_request["includeMemorySnapshot"] = True
             if request["memoryQuery"]:
                 pi_request["memory"]["query"] = request["memoryQuery"]
         event = {
@@ -453,9 +455,36 @@ def _parse_pi_event(raw: bytes) -> dict[str, Any]:
         value = json.loads(raw)
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise UpstreamUnavailable("Pi agent returned malformed events") from exc
-    if not isinstance(value, dict) or value.get("type") not in _PI_EVENT_FIELDS:
+    if not isinstance(value, dict):
         raise UpstreamUnavailable("Pi agent returned malformed events")
-    event_type = value["type"]
+    event_type = value.get("type")
+    if not isinstance(event_type, str):
+        raise UpstreamUnavailable("Pi agent returned malformed events")
+    if event_type == "memory_snapshot":
+        scope_id = value.get("scopeId")
+        queries = value.get("queries")
+        memories = value.get("memories")
+        if (
+            not isinstance(scope_id, str)
+            or not _BANK_RE.fullmatch(scope_id)
+            or not isinstance(queries, list)
+            or len(queries) > 2
+            or not all(
+                isinstance(query, str) and 1 <= len(query) <= 8_000
+                for query in queries
+            )
+            or not isinstance(memories, list)
+            or len(memories) > 50
+        ):
+            raise UpstreamUnavailable("Pi agent returned malformed events")
+        return {
+            "type": "memory_snapshot",
+            "scopeId": scope_id,
+            "queries": queries,
+            "memories": [_parse_snapshot_memory(item) for item in memories],
+        }
+    if event_type not in _PI_EVENT_FIELDS:
+        raise UpstreamUnavailable("Pi agent returned malformed events")
     result: dict[str, Any] = {"type": event_type}
     for field in _PI_EVENT_FIELDS[event_type]:
         supplied = value.get(field)
@@ -467,6 +496,49 @@ def _parse_pi_event(raw: bytes) -> dict[str, Any]:
         elif not isinstance(supplied, str) or len(supplied) > 64_000:
             raise UpstreamUnavailable("Pi agent returned malformed events")
         result[field] = supplied
+    return result
+
+
+def _parse_snapshot_memory(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise UpstreamUnavailable("Pi agent returned malformed events")
+    memory_id = value.get("id")
+    text = value.get("text")
+    entities = value.get("entities")
+    if (
+        not isinstance(memory_id, str)
+        or not _MEMORY_ID_RE.fullmatch(memory_id)
+        or not isinstance(text, str)
+        or not 1 <= len(text) <= 16_000
+        or not isinstance(entities, list)
+        or len(entities) > 100
+        or not all(isinstance(entity, str) and len(entity) <= 256 for entity in entities)
+    ):
+        raise UpstreamUnavailable("Pi agent returned malformed events")
+    result: dict[str, Any] = {
+        "id": memory_id,
+        "text": text,
+        "entities": entities,
+    }
+    for key, maximum in (
+        ("type", 16_000),
+        ("occurredStart", 16_000),
+        ("occurredEnd", 16_000),
+        ("mentionedAt", 16_000),
+        ("documentId", 512),
+        ("chunkId", 512),
+    ):
+        supplied = value.get(key)
+        if supplied is not None and (
+            not isinstance(supplied, str)
+            or len(supplied) > maximum
+            or (
+                key in {"documentId", "chunkId"}
+                and not _DOCUMENT_ID_RE.fullmatch(supplied)
+            )
+        ):
+            raise UpstreamUnavailable("Pi agent returned malformed events")
+        result[key] = supplied
     return result
 
 

--- a/playground/src/agent_playground/assets/app.js
+++ b/playground/src/agent_playground/assets/app.js
@@ -180,6 +180,18 @@ function handleEvent(event, assistant) {
     renderInspector();
     return;
   }
+  if (event.type === "memory_snapshot") {
+    state.memory = {
+      bankId: event.scopeId,
+      query: event.queries.join("\n\n"),
+      queries: event.queries,
+      memories: event.memories,
+      managedBy: "agent",
+      status: "complete",
+    };
+    renderInspector();
+    return;
+  }
   if (event.type === "run_started") return;
   if (event.type === "tool_snapshot") {
     state.tools.push(event);
@@ -250,14 +262,29 @@ function renderMemory() {
   }
   const blocks = [
     field("Bank", state.memory.bankId),
-    field("Recall query", state.memory.query),
+    field(
+      Array.isArray(state.memory.queries) && state.memory.queries.length > 1
+        ? "Recall queries"
+        : "Recall query",
+      state.memory.query,
+    ),
   ];
   const memories = Array.isArray(state.memory.memories) ? state.memory.memories : [];
-  if (memories.length === 0) blocks.push(node("p", "No matching memories.", "empty-inspector"));
+  if (state.memory.status === "pending") {
+    blocks.push(node("p", "Agent is fetching memory...", "empty-inspector"));
+  } else if (memories.length === 0) {
+    blocks.push(node("p", "No matching memories.", "empty-inspector"));
+  }
   for (const memory of memories) {
     const item = node("section", null, "memory-item");
     item.append(node("div", memory.type || "memory", "memory-type"));
     item.append(node("p", memory.text, "memory-text"));
+    const metadata = [
+      ...(memory.entities || []),
+      memory.occurredStart,
+      memory.documentId,
+    ].filter(Boolean).join(" · ");
+    if (metadata) item.append(node("div", metadata, "memory-meta"));
     item.append(node("code", memory.id, "memory-id"));
     blocks.push(item);
   }

--- a/playground/src/agent_playground/assets/styles.css
+++ b/playground/src/agent_playground/assets/styles.css
@@ -78,6 +78,7 @@ textarea:focus, select:focus, button:focus-visible { outline: 2px solid #087f75;
 .memory-item { padding: 11px 0; border-bottom: 1px solid #d9dfe1; }
 .memory-type { color: #976000; font-size: 11px; font-weight: 700; text-transform: uppercase; }
 .memory-text { margin: 5px 0 7px; line-height: 1.45; white-space: pre-wrap; }
+.memory-meta { margin: 0 0 7px; color: #536066; font-size: 11px; line-height: 1.45; overflow-wrap: anywhere; }
 .memory-id { color: #657176; font-size: 10px; overflow-wrap: anywhere; }
 .tool-row { display: grid; gap: 3px; padding: 10px 0; border-bottom: 1px solid #d9dfe1; }
 .tool-name { color: #7f4d00; font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; font-weight: 700; }

--- a/playground/tests/test_agent_playground.py
+++ b/playground/tests/test_agent_playground.py
@@ -6,7 +6,12 @@ import aiohttp
 from aiohttp import web
 import pytest
 
-from agent_playground.app import PlaygroundSettings, create_app
+from agent_playground.app import (
+    PlaygroundSettings,
+    UpstreamUnavailable,
+    _parse_pi_event,
+    create_app,
+)
 
 
 async def start(app: web.Application) -> tuple[web.AppRunner, str]:
@@ -77,6 +82,24 @@ async def dependencies() -> tuple[list[web.AppRunner], str, str, dict]:
         )
         await response.prepare(request)
         events = (
+            {
+                "type": "memory_snapshot",
+                "scopeId": payload["memory"]["scopeId"],
+                "queries": ["Who owns deploys?"],
+                "memories": [
+                    {
+                        "id": "memory-1",
+                        "text": "Alice maintains the deployment pipeline.",
+                        "type": "world",
+                        "entities": ["Alice", "actor:alice"],
+                        "occurredStart": "2026-07-13T12:00:00Z",
+                        "occurredEnd": None,
+                        "mentionedAt": "2026-07-13T12:01:00Z",
+                        "documentId": "conversation:41",
+                        "chunkId": "chunk-1",
+                    }
+                ],
+            },
             {
                 "type": "run_started",
                 "runId": payload["runId"],
@@ -189,10 +212,13 @@ async def test_agent_run_delegates_memory_to_pi_and_streams_events():
             "query": "Automatic from request and references",
             "memories": [],
             "managedBy": "agent",
+            "status": "pending",
         }
         assert prepared["request"]["systemPrompt"] == "Use evidence carefully."
         assert events[-1]["type"] == "run_completed"
         assert events[-1]["answer"] == "Alice owns it."
+        assert events[1]["type"] == "memory_snapshot"
+        assert events[1]["memories"][0]["id"] == "memory-1"
 
         assert len(received["recalls"]) == 1
         pi_request = received["runs"][0]
@@ -201,6 +227,7 @@ async def test_agent_run_delegates_memory_to_pi_and_streams_events():
             "scopeId": "chat:engineering",
             "anchors": [],
         }
+        assert pi_request["includeMemorySnapshot"] is True
         assert [item["kind"] for item in pi_request["context"]] == [
             "reference",
             "reference",
@@ -285,6 +312,7 @@ async def test_playground_rejects_invalid_input_and_untrusted_hosts():
                 assert "innerHTML" not in script
                 assert "textContent" in script
                 assert 'if (event.type === "run_started") return;' in script
+                assert 'if (event.type === "memory_snapshot")' in script
                 assert (
                     "state.sessionId = event.sessionId || state.sessionId" not in script
                 )
@@ -294,3 +322,27 @@ async def test_playground_rejects_invalid_input_and_untrusted_hosts():
         await playground_runner.cleanup()
         for runner in dependency_runners:
             await runner.cleanup()
+
+
+@pytest.mark.parametrize(
+    "event",
+    (
+        {},
+        {
+            "type": "memory_snapshot",
+            "scopeId": "chat:engineering",
+            "queries": ["Who owns deploys?"],
+            "memories": [
+                {
+                    "id": "memory-1",
+                    "text": "Alice maintains the deployment pipeline.",
+                    "entities": ["Alice"],
+                    "documentId": "not a valid source id",
+                }
+            ],
+        },
+    ),
+)
+def test_playground_rejects_malformed_pi_memory_events(event):
+    with pytest.raises(UpstreamUnavailable, match="malformed events"):
+        _parse_pi_event(json.dumps(event).encode())


### PR DESCRIPTION
## Summary
- add an opt-in Pi memory snapshot event for private diagnostic clients
- let Agent Playground render the exact memories Pi injected after recall
- validate and bound snapshot fields, with loading and empty states

## Verification
- `npm test` (42 passed)
- `playground/.venv/bin/pytest -q` (6 passed)
- `.venv/bin/pytest -q` (191 passed, 6 skipped)
- live Docker smoke test against Coder Offtopic memory bank
- desktop and mobile browser checks; no console errors