### PR TITLE
Fix Playground runs behind dashboard proxy

### DIFF
--- a/playground/src/agent_playground/app.py
+++ b/playground/src/agent_playground/app.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 import re
 from typing import Any, ClassVar
-from urllib.parse import quote, urlencode, urlsplit
+from urllib.parse import quote, urlencode
 from uuid import uuid4
 
 import aiohttp
@@ -847,20 +847,6 @@ def _valid_host(value: str) -> bool:
     return port is None or 1 <= int(port) <= 65_535
 
 
-def _valid_origin(request: web.Request) -> bool:
-    origin = request.headers.get("Origin")
-    if origin is None:
-        return True
-    try:
-        parsed = urlsplit(origin)
-    except ValueError:
-        return False
-    return (
-        parsed.scheme in {"http", "https"}
-        and parsed.netloc.casefold() == request.host.casefold()
-    )
-
-
 DATA_KEY = web.AppKey("playground_data", PlaygroundData)
 
 
@@ -869,8 +855,6 @@ async def _private_request(request: web.Request, handler: Any) -> web.StreamResp
     hosts = request.headers.getall("Host", [])
     if len(hosts) != 1 or not _valid_host(hosts[0]):
         return web.Response(status=400, text="Invalid Host header")
-    if request.method not in {"GET", "HEAD"} and not _valid_origin(request):
-        return _error_response(403, "FORBIDDEN", "Cross-origin request rejected")
     return await handler(request)
 
 

--- a/playground/tests/test_agent_playground.py
+++ b/playground/tests/test_agent_playground.py
@@ -296,7 +296,7 @@ def test_settings_use_generic_environment_names(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_agent_run_delegates_memory_to_pi_and_streams_events():
+async def test_agent_run_accepts_proxy_origin_and_streams_pi_events():
     dependency_runners, memory_url, pi_url, received = await dependencies()
     playground_runner, playground_url = await request_app(memory_url, pi_url)
     try:
@@ -320,6 +320,7 @@ async def test_agent_run_delegates_memory_to_pi_and_streams_events():
 
             async with session.post(
                 f"{playground_url}/api/runs",
+                headers={"Origin": "http://sessions.telefire.localhost:18865"},
                 json={
                     "mode": "agent",
                     "prompt": "Who owns deploys?",


### PR DESCRIPTION
## Summary
- remove the Playground backend Origin-to-Host rejection
- cover proxied public origins on the real streamed run path
- retain Host validation and browser security headers

## Verification
- `uv run --project playground pytest playground/tests/test_agent_playground.py -q` (8 passed)
- `uv run pytest -q` (205 passed, 6 skipped)
- `python3.14 -m py_compile playground/src/agent_playground/app.py`