### PR TITLE
Add reproducible chat-memory backend benchmark

### DIFF
--- a/src/telefire/memory_benchmark/__init__.py
+++ b/src/telefire/memory_benchmark/__init__.py
@@ -1,0 +1,1 @@
+"""Hindsight and TencentDB Agent Memory comparison harness."""

--- a/src/telefire/memory_benchmark/backends.py
+++ b/src/telefire/memory_benchmark/backends.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import re
+import sqlite3
+from time import perf_counter
+from typing import Any
+from urllib.parse import quote
+
+import aiohttp
+
+from telefire.memory_benchmark.source import SourceCorpus
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRecord:
+    backend: str
+    memory_id: str
+    text: str
+    memory_type: str
+    document_id: str | None
+    entities: tuple[str, ...] = ()
+    occurred_start: str | None = None
+    occurred_end: str | None = None
+    mentioned_at: str | None = None
+    scene_name: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RecallMeasurement:
+    backend: str
+    query: str
+    elapsed_ms: float
+    records: tuple[MemoryRecord, ...]
+    raw_context: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "backend": self.backend,
+            "query": self.query,
+            "elapsed_ms": self.elapsed_ms,
+            "records": [record.to_dict() for record in self.records],
+            "raw_context": self.raw_context,
+        }
+
+
+async def ingest_hindsight(
+    base_url: str,
+    bank_id: str,
+    bank_name: str,
+    corpus: SourceCorpus,
+    *,
+    batch_size: int = 4,
+) -> dict[str, Any]:
+    timeout = aiohttp.ClientTimeout(total=900)
+    encoded_bank = quote(bank_id, safe="")
+    started = perf_counter()
+    operations = []
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        await _json_request(
+            session,
+            "PUT",
+            f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}",
+            json={"name": bank_name},
+        )
+        for index in range(0, len(corpus.documents), batch_size):
+            documents = corpus.documents[index : index + batch_size]
+            payload = await _json_request(
+                session,
+                "POST",
+                f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}/memories",
+                json={
+                    "async": False,
+                    "items": [
+                        {
+                            "content": document.content,
+                            "context": document.context,
+                            "timestamp": document.timestamp,
+                            "document_id": document.document_id,
+                            "update_mode": "replace",
+                            "metadata": {
+                                "client": "telefire-memory-benchmark",
+                                "source": "telegram",
+                                "scope_id": corpus.bank_id,
+                                "content_hash": document.content_hash,
+                            },
+                            "entities": [
+                                {"text": actor_id, "type": "PERSON"}
+                                for actor_id in sorted(
+                                    {event.actor_id for event in document.events}
+                                )
+                            ],
+                        }
+                        for document in documents
+                    ],
+                },
+            )
+            if payload.get("success") is not True:
+                raise RuntimeError(f"Hindsight rejected batch at document {index}")
+            operations.append(payload.get("operation_id"))
+
+        stats = await wait_for_hindsight_idle(session, base_url, bank_id)
+    return {
+        "backend": "hindsight-fresh",
+        "elapsed_seconds": perf_counter() - started,
+        "documents": len(corpus.documents),
+        "operations": len(operations),
+        "stats": stats,
+    }
+
+
+async def wait_for_hindsight_idle(
+    session: aiohttp.ClientSession,
+    base_url: str,
+    bank_id: str,
+    *,
+    timeout_seconds: float = 900,
+) -> dict[str, Any]:
+    encoded_bank = quote(bank_id, safe="")
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    stable = 0
+    latest: dict[str, Any] = {}
+    while asyncio.get_running_loop().time() < deadline:
+        latest = await _json_request(
+            session,
+            "GET",
+            f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}/stats",
+        )
+        pending = int(latest.get("pending_operations", 0)) + int(
+            latest.get("pending_consolidation", 0)
+        )
+        failed = int(latest.get("failed_operations", 0)) + int(
+            latest.get("failed_consolidation", 0)
+        )
+        if failed:
+            raise RuntimeError(f"Hindsight reported {failed} failed operations")
+        stable = stable + 1 if pending == 0 else 0
+        if stable >= 3:
+            return latest
+        await asyncio.sleep(2)
+    raise TimeoutError("Hindsight did not become idle")
+
+
+async def list_hindsight_memories(
+    base_url: str,
+    bank_id: str,
+    *,
+    backend: str,
+) -> tuple[MemoryRecord, ...]:
+    timeout = aiohttp.ClientTimeout(total=120)
+    encoded_bank = quote(bank_id, safe="")
+    offset = 0
+    records = []
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        while True:
+            payload = await _json_request(
+                session,
+                "GET",
+                f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}/memories/list",
+                params={"limit": "100", "offset": str(offset)},
+            )
+            items = payload.get("items")
+            total = payload.get("total")
+            if not isinstance(items, list) or not isinstance(total, int):
+                raise ValueError("Hindsight returned a malformed memory page")
+            records.extend(_hindsight_record(backend, item) for item in items)
+            offset += len(items)
+            if offset >= total:
+                break
+            if not items:
+                raise ValueError("Hindsight memory pagination stopped early")
+    return tuple(records)
+
+
+async def recall_hindsight(
+    base_url: str,
+    bank_id: str,
+    query: str,
+    *,
+    backend: str,
+    max_tokens: int = 2_000,
+) -> RecallMeasurement:
+    timeout = aiohttp.ClientTimeout(total=120)
+    encoded_bank = quote(bank_id, safe="")
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        started = perf_counter()
+        payload = await _json_request(
+            session,
+            "POST",
+            f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}/memories/recall",
+            json={
+                "query": query,
+                "budget": "mid",
+                "max_tokens": max_tokens,
+                "types": ["world", "experience", "observation"],
+                "prefer_observations": True,
+                "include": {
+                    "entities": {"max_tokens": 500},
+                    "source_facts": {"max_tokens": 750},
+                },
+            },
+        )
+        elapsed_ms = (perf_counter() - started) * 1_000
+    items = payload.get("results")
+    if not isinstance(items, list):
+        raise ValueError("Hindsight returned malformed recall results")
+    records = tuple(_hindsight_recall_record(backend, item) for item in items)
+    return RecallMeasurement(
+        backend=backend,
+        query=query,
+        elapsed_ms=elapsed_ms,
+        records=records,
+        raw_context="\n".join(record.text for record in records),
+    )
+
+
+async def seed_tencent(
+    base_url: str,
+    seed_data: dict[str, Any],
+) -> dict[str, Any]:
+    timeout = aiohttp.ClientTimeout(total=10_800)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        started = perf_counter()
+        payload = await _json_request(
+            session,
+            "POST",
+            f"{base_url.rstrip('/')}/seed",
+            json={
+                "data": seed_data,
+                "strict_round_role": False,
+                "auto_fill_timestamps": False,
+            },
+        )
+    payload["elapsed_seconds_client"] = perf_counter() - started
+    return payload
+
+
+async def recall_tencent(
+    base_url: str,
+    query: str,
+    *,
+    limit: int = 10,
+) -> RecallMeasurement:
+    timeout = aiohttp.ClientTimeout(total=120)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        started = perf_counter()
+        payload = await _json_request(
+            session,
+            "POST",
+            f"{base_url.rstrip('/')}/search/memories",
+            json={"query": query, "limit": limit},
+        )
+        elapsed_ms = (perf_counter() - started) * 1_000
+    results = payload.get("results")
+    if not isinstance(results, str):
+        raise ValueError("Tencent returned malformed memory search results")
+    return RecallMeasurement(
+        backend="tencent-l1",
+        query=query,
+        elapsed_ms=elapsed_ms,
+        records=parse_tencent_search(results),
+        raw_context=results,
+    )
+
+
+def parse_tencent_search(value: str) -> tuple[MemoryRecord, ...]:
+    records = []
+    current_type: str | None = None
+    current_scene: str | None = None
+    current_id = 0
+    header = re.compile(r"^- \*\*\[(?P<type>[^]]+)]\*\*")
+    scene = re.compile(r"\[scene: (?P<scene>[^]]+)]")
+    for line in value.splitlines():
+        match = header.match(line)
+        if match:
+            current_type = match.group("type")
+            scene_match = scene.search(line)
+            current_scene = scene_match.group("scene") if scene_match else None
+            continue
+        if current_type and line.startswith("  ") and line.strip():
+            current_id += 1
+            records.append(
+                MemoryRecord(
+                    backend="tencent-l1",
+                    memory_id=f"search-result-{current_id}",
+                    text=line.strip(),
+                    memory_type=current_type,
+                    document_id=None,
+                    scene_name=current_scene,
+                )
+            )
+            current_type = None
+            current_scene = None
+    return tuple(records)
+
+
+def read_tencent_memories(database: Path) -> tuple[MemoryRecord, ...]:
+    uri = f"file:{database.resolve()}?mode=ro"
+    connection = sqlite3.connect(uri, uri=True)
+    try:
+        rows = connection.execute(
+            """
+            SELECT record_id, content, type, scene_name, session_id,
+                   timestamp_start, timestamp_end
+            FROM l1_records
+            ORDER BY created_time, record_id
+            """
+        ).fetchall()
+    finally:
+        connection.close()
+    return tuple(
+        MemoryRecord(
+            backend="tencent-l1",
+            memory_id=row[0],
+            text=row[1],
+            memory_type=row[2],
+            document_id=row[4] or None,
+            occurred_start=row[5] or None,
+            occurred_end=row[6] or None,
+            scene_name=row[3] or None,
+        )
+        for row in rows
+    )
+
+
+async def _json_request(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    async with session.request(method, url, **kwargs) as response:
+        text = await response.text()
+        if response.status >= 400:
+            raise RuntimeError(f"{method} {url} failed with status {response.status}: {text[:500]}")
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{method} {url} returned invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"{method} {url} returned a non-object response")
+        return payload
+
+
+def _hindsight_record(backend: str, item: Any) -> MemoryRecord:
+    if not isinstance(item, dict):
+        raise ValueError("Hindsight returned a malformed memory")
+    entities = item.get("entities") or ""
+    if isinstance(entities, str):
+        parsed_entities = tuple(part.strip() for part in entities.split(",") if part.strip())
+    elif isinstance(entities, list) and all(isinstance(part, str) for part in entities):
+        parsed_entities = tuple(entities)
+    else:
+        raise ValueError("Hindsight returned malformed memory entities")
+    return MemoryRecord(
+        backend=backend,
+        memory_id=_string(item, "id"),
+        text=_string(item, "text"),
+        memory_type=_string(item, "fact_type"),
+        document_id=_optional(item, "document_id"),
+        entities=parsed_entities,
+        occurred_start=_optional(item, "occurred_start"),
+        occurred_end=_optional(item, "occurred_end"),
+        mentioned_at=_optional(item, "mentioned_at"),
+    )
+
+
+def _hindsight_recall_record(backend: str, item: Any) -> MemoryRecord:
+    if not isinstance(item, dict):
+        raise ValueError("Hindsight returned a malformed recalled memory")
+    entities = item.get("entities") or []
+    if not isinstance(entities, list) or not all(isinstance(part, str) for part in entities):
+        raise ValueError("Hindsight returned malformed recalled entities")
+    return MemoryRecord(
+        backend=backend,
+        memory_id=_string(item, "id"),
+        text=_string(item, "text"),
+        memory_type=_optional(item, "type") or "unknown",
+        document_id=_optional(item, "document_id"),
+        entities=tuple(entities),
+        occurred_start=_optional(item, "occurred_start"),
+        occurred_end=_optional(item, "occurred_end"),
+        mentioned_at=_optional(item, "mentioned_at"),
+    )
+
+
+def _string(payload: dict[str, Any], name: str) -> str:
+    value = payload.get(name)
+    if not isinstance(value, str):
+        raise ValueError(f"Missing or invalid {name}")
+    return value
+
+
+def _optional(payload: dict[str, Any], name: str) -> str | None:
+    value = payload.get(name)
+    if value is not None and not isinstance(value, str):
+        raise ValueError(f"Invalid {name}")
+    return value

--- a/src/telefire/memory_benchmark/backends.py
+++ b/src/telefire/memory_benchmark/backends.py
@@ -56,9 +56,12 @@ async def ingest_hindsight(
     bank_name: str,
     corpus: SourceCorpus,
     *,
-    batch_size: int = 4,
+    batch_size: int = 1,
+    concurrency: int = 4,
     progress: Callable[[int, int], None] | None = None,
 ) -> dict[str, Any]:
+    if batch_size < 1 or concurrency < 1:
+        raise ValueError("batch_size and concurrency must be positive")
     timeout = aiohttp.ClientTimeout(total=900)
     encoded_bank = quote(bank_id, safe="")
     started = perf_counter()
@@ -70,8 +73,13 @@ async def ingest_hindsight(
             f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}",
             json={"name": bank_name},
         )
-        for index in range(0, len(corpus.documents), batch_size):
-            documents = corpus.documents[index : index + batch_size]
+        batches = [
+            corpus.documents[index : index + batch_size]
+            for index in range(0, len(corpus.documents), batch_size)
+        ]
+
+        async def retain_batch(index: int) -> dict[str, Any]:
+            documents = batches[index]
             payload = await _json_request(
                 session,
                 "POST",
@@ -103,10 +111,19 @@ async def ingest_hindsight(
                 },
             )
             if payload.get("success") is not True:
-                raise RuntimeError(f"Hindsight rejected batch at document {index}")
-            operations.append(payload.get("operation_id"))
+                raise RuntimeError(f"Hindsight rejected batch {index}")
+            return payload
+
+        completed_documents = 0
+        for start in range(0, len(batches), concurrency):
+            wave = batches[start : start + concurrency]
+            payloads = await asyncio.gather(
+                *(retain_batch(index) for index in range(start, start + len(wave)))
+            )
+            operations.extend(payload.get("operation_id") for payload in payloads)
+            completed_documents += sum(len(documents) for documents in wave)
             if progress is not None:
-                progress(min(index + len(documents), len(corpus.documents)), len(corpus.documents))
+                progress(completed_documents, len(corpus.documents))
 
         stats = await wait_for_hindsight_idle(session, base_url, bank_id)
     return {
@@ -114,6 +131,7 @@ async def ingest_hindsight(
         "elapsed_seconds": perf_counter() - started,
         "documents": len(corpus.documents),
         "batch_size": batch_size,
+        "concurrency": concurrency,
         "operations": len(operations),
         "stats": stats,
     }

--- a/src/telefire/memory_benchmark/backends.py
+++ b/src/telefire/memory_benchmark/backends.py
@@ -113,6 +113,7 @@ async def ingest_hindsight(
         "backend": "hindsight-fresh",
         "elapsed_seconds": perf_counter() - started,
         "documents": len(corpus.documents),
+        "batch_size": batch_size,
         "operations": len(operations),
         "stats": stats,
     }

--- a/src/telefire/memory_benchmark/backends.py
+++ b/src/telefire/memory_benchmark/backends.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import re
 import sqlite3
 from time import perf_counter
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import quote
 
 import aiohttp
@@ -21,7 +21,7 @@ class MemoryRecord:
     memory_id: str
     text: str
     memory_type: str
-    document_id: str | None
+    source_document_ids: tuple[str, ...] = ()
     entities: tuple[str, ...] = ()
     occurred_start: str | None = None
     occurred_end: str | None = None
@@ -57,6 +57,7 @@ async def ingest_hindsight(
     corpus: SourceCorpus,
     *,
     batch_size: int = 4,
+    progress: Callable[[int, int], None] | None = None,
 ) -> dict[str, Any]:
     timeout = aiohttp.ClientTimeout(total=900)
     encoded_bank = quote(bank_id, safe="")
@@ -104,6 +105,8 @@ async def ingest_hindsight(
             if payload.get("success") is not True:
                 raise RuntimeError(f"Hindsight rejected batch at document {index}")
             operations.append(payload.get("operation_id"))
+            if progress is not None:
+                progress(min(index + len(documents), len(corpus.documents)), len(corpus.documents))
 
         stats = await wait_for_hindsight_idle(session, base_url, bank_id)
     return {
@@ -131,6 +134,7 @@ async def wait_for_hindsight_idle(
             session,
             "GET",
             f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}/stats",
+            params={"refresh": "true"},
         )
         pending = int(latest.get("pending_operations", 0)) + int(
             latest.get("pending_consolidation", 0)
@@ -156,7 +160,7 @@ async def list_hindsight_memories(
     timeout = aiohttp.ClientTimeout(total=120)
     encoded_bank = quote(bank_id, safe="")
     offset = 0
-    records = []
+    all_items: list[dict[str, Any]] = []
     async with aiohttp.ClientSession(timeout=timeout) as session:
         while True:
             payload = await _json_request(
@@ -165,17 +169,67 @@ async def list_hindsight_memories(
                 f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}/memories/list",
                 params={"limit": "100", "offset": str(offset)},
             )
-            items = payload.get("items")
+            page_items = payload.get("items")
             total = payload.get("total")
-            if not isinstance(items, list) or not isinstance(total, int):
+            if not isinstance(page_items, list) or not isinstance(total, int):
                 raise ValueError("Hindsight returned a malformed memory page")
-            records.extend(_hindsight_record(backend, item) for item in items)
-            offset += len(items)
+            all_items.extend(page_items)
+            offset += len(page_items)
             if offset >= total:
                 break
-            if not items:
+            if not page_items:
                 raise ValueError("Hindsight memory pagination stopped early")
-    return tuple(records)
+
+        documents_by_memory = {
+            _string(item, "id"): document_id
+            for item in all_items
+            if (document_id := _optional(item, "document_id")) is not None
+        }
+        observation_ids = [
+            _string(item, "id")
+            for item in all_items
+            if item.get("fact_type") == "observation"
+        ]
+        semaphore = asyncio.Semaphore(12)
+
+        async def observation_sources(memory_id: str) -> tuple[str, ...]:
+            async with semaphore:
+                detail = await _json_request(
+                    session,
+                    "GET",
+                    f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}/memories/"
+                    f"{quote(memory_id, safe='')}",
+                )
+            source_ids = detail.get("source_memory_ids") or []
+            if not isinstance(source_ids, list) or not all(
+                isinstance(source_id, str) for source_id in source_ids
+            ):
+                raise ValueError("Hindsight returned malformed observation sources")
+            return tuple(
+                dict.fromkeys(
+                    documents_by_memory[source_id]
+                    for source_id in source_ids
+                    if source_id in documents_by_memory
+                )
+            )
+
+        observation_documents = dict(
+            zip(
+                observation_ids,
+                await asyncio.gather(
+                    *(observation_sources(memory_id) for memory_id in observation_ids)
+                ),
+                strict=True,
+            )
+        )
+    return tuple(
+        _hindsight_record(
+            backend,
+            item,
+            inherited_source_documents=observation_documents.get(_string(item, "id"), ()),
+        )
+        for item in all_items
+    )
 
 
 async def recall_hindsight(
@@ -291,7 +345,6 @@ def parse_tencent_search(value: str) -> tuple[MemoryRecord, ...]:
                     memory_id=f"search-result-{current_id}",
                     text=line.strip(),
                     memory_type=current_type,
-                    document_id=None,
                     scene_name=current_scene,
                 )
             )
@@ -300,18 +353,23 @@ def parse_tencent_search(value: str) -> tuple[MemoryRecord, ...]:
     return tuple(records)
 
 
-def read_tencent_memories(database: Path) -> tuple[MemoryRecord, ...]:
+def read_tencent_memories(
+    database: Path,
+    *,
+    records_directory: Path | None = None,
+) -> tuple[MemoryRecord, ...]:
     uri = f"file:{database.resolve()}?mode=ro"
     connection = sqlite3.connect(uri, uri=True)
     try:
         rows = connection.execute(
             """
-            SELECT record_id, content, type, scene_name, session_id,
+            SELECT record_id, content, type, scene_name,
                    timestamp_start, timestamp_end
             FROM l1_records
             ORDER BY created_time, record_id
             """
         ).fetchall()
+        source_documents = _tencent_source_documents(connection, records_directory)
     finally:
         connection.close()
     return tuple(
@@ -320,13 +378,53 @@ def read_tencent_memories(database: Path) -> tuple[MemoryRecord, ...]:
             memory_id=row[0],
             text=row[1],
             memory_type=row[2],
-            document_id=row[4] or None,
-            occurred_start=row[5] or None,
-            occurred_end=row[6] or None,
+            source_document_ids=source_documents.get(row[0], ()),
+            occurred_start=row[4] or None,
+            occurred_end=row[5] or None,
             scene_name=row[3] or None,
         )
         for row in rows
     )
+
+
+def _tencent_source_documents(
+    connection: sqlite3.Connection,
+    records_directory: Path | None,
+) -> dict[str, tuple[str, ...]]:
+    if records_directory is None or not records_directory.exists():
+        return {}
+
+    memory_sources: dict[str, tuple[str, ...]] = {}
+    for path in sorted(records_directory.glob("*.jsonl")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            value = json.loads(line)
+            memory_id = value.get("id")
+            source_ids = value.get("source_message_ids") or []
+            if isinstance(memory_id, str) and all(
+                isinstance(source_id, str) for source_id in source_ids
+            ):
+                memory_sources[memory_id] = tuple(source_ids)
+
+    source_rows = connection.execute(
+        "SELECT record_id, message_text FROM l0_conversations"
+    ).fetchall()
+    source_pattern = re.compile(r"^\[Source document: ([^]]+)]$", re.MULTILINE)
+    documents_by_source = {
+        source_id: tuple(dict.fromkeys(source_pattern.findall(message_text)))
+        for source_id, message_text in source_rows
+    }
+    return {
+        memory_id: tuple(
+            dict.fromkeys(
+                document_id
+                for source_id in source_ids
+                for document_id in documents_by_source.get(source_id, ())
+            )
+        )
+        for memory_id, source_ids in memory_sources.items()
+    }
 
 
 async def _json_request(
@@ -348,7 +446,12 @@ async def _json_request(
         return payload
 
 
-def _hindsight_record(backend: str, item: Any) -> MemoryRecord:
+def _hindsight_record(
+    backend: str,
+    item: Any,
+    *,
+    inherited_source_documents: tuple[str, ...] = (),
+) -> MemoryRecord:
     if not isinstance(item, dict):
         raise ValueError("Hindsight returned a malformed memory")
     entities = item.get("entities") or ""
@@ -363,7 +466,11 @@ def _hindsight_record(backend: str, item: Any) -> MemoryRecord:
         memory_id=_string(item, "id"),
         text=_string(item, "text"),
         memory_type=_string(item, "fact_type"),
-        document_id=_optional(item, "document_id"),
+        source_document_ids=(
+            (document_id,)
+            if (document_id := _optional(item, "document_id"))
+            else inherited_source_documents
+        ),
         entities=parsed_entities,
         occurred_start=_optional(item, "occurred_start"),
         occurred_end=_optional(item, "occurred_end"),
@@ -382,7 +489,7 @@ def _hindsight_recall_record(backend: str, item: Any) -> MemoryRecord:
         memory_id=_string(item, "id"),
         text=_string(item, "text"),
         memory_type=_optional(item, "type") or "unknown",
-        document_id=_optional(item, "document_id"),
+        source_document_ids=(document_id,) if (document_id := _optional(item, "document_id")) else (),
         entities=tuple(entities),
         occurred_start=_optional(item, "occurred_start"),
         occurred_end=_optional(item, "occurred_end"),

--- a/src/telefire/memory_benchmark/backends.py
+++ b/src/telefire/memory_benchmark/backends.py
@@ -272,7 +272,6 @@ async def recall_hindsight(
                 "budget": "mid",
                 "max_tokens": max_tokens,
                 "types": ["world", "experience", "observation"],
-                "prefer_observations": True,
                 "include": {
                     "entities": {"max_tokens": 500},
                     "source_facts": {"max_tokens": 750},

--- a/src/telefire/memory_benchmark/backends.py
+++ b/src/telefire/memory_benchmark/backends.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import asdict, dataclass
+from datetime import datetime
 import json
 from pathlib import Path
 import re
@@ -12,7 +13,7 @@ from urllib.parse import quote
 
 import aiohttp
 
-from telefire.memory_benchmark.source import SourceCorpus
+from telefire.memory_benchmark.source import SourceCorpus, SourceDocument
 
 
 @dataclass(frozen=True, slots=True)
@@ -375,6 +376,7 @@ def read_tencent_memories(
     database: Path,
     *,
     records_directory: Path | None = None,
+    corpus: SourceCorpus | None = None,
 ) -> tuple[MemoryRecord, ...]:
     uri = f"file:{database.resolve()}?mode=ro"
     connection = sqlite3.connect(uri, uri=True)
@@ -387,7 +389,11 @@ def read_tencent_memories(
             ORDER BY created_time, record_id
             """
         ).fetchall()
-        source_documents = _tencent_source_documents(connection, records_directory)
+        source_documents = _tencent_source_documents(
+            connection,
+            records_directory,
+            corpus,
+        )
     finally:
         connection.close()
     return tuple(
@@ -408,6 +414,7 @@ def read_tencent_memories(
 def _tencent_source_documents(
     connection: sqlite3.Connection,
     records_directory: Path | None,
+    corpus: SourceCorpus | None,
 ) -> dict[str, tuple[str, ...]]:
     if records_directory is None or not records_directory.exists():
         return {}
@@ -426,13 +433,27 @@ def _tencent_source_documents(
                 memory_sources[memory_id] = tuple(source_ids)
 
     source_rows = connection.execute(
-        "SELECT record_id, message_text FROM l0_conversations"
+        "SELECT record_id, message_text, timestamp FROM l0_conversations"
     ).fetchall()
     source_pattern = re.compile(r"^\[Source document: ([^]]+)]$", re.MULTILINE)
-    documents_by_source = {
-        source_id: tuple(dict.fromkeys(source_pattern.findall(message_text)))
-        for source_id, message_text in source_rows
-    }
+    expected_documents: dict[tuple[int, str], list[str]] = {}
+    if corpus is not None:
+        for document in corpus.documents:
+            parsed = datetime.fromisoformat(document.timestamp.replace("Z", "+00:00"))
+            timestamp_ms = int(parsed.timestamp() * 1_000)
+            expected_documents.setdefault(
+                (timestamp_ms, _tencent_l0_content(document)), []
+            ).append(document.document_id)
+
+    documents_by_source = {}
+    for source_id, message_text, timestamp in source_rows:
+        embedded = tuple(dict.fromkeys(source_pattern.findall(message_text)))
+        if embedded:
+            documents_by_source[source_id] = embedded
+        elif isinstance(timestamp, int):
+            documents_by_source[source_id] = tuple(
+                expected_documents.get((timestamp, message_text), ())
+            )
     return {
         memory_id: tuple(
             dict.fromkeys(
@@ -443,6 +464,13 @@ def _tencent_source_documents(
         )
         for memory_id, source_ids in memory_sources.items()
     }
+
+
+def _tencent_l0_content(document: SourceDocument) -> str:
+    return "\n".join(
+        f"[Telegram actor: {event.actor_name} | {event.actor_id}] {event.text}"
+        for event in document.events
+    )
 
 
 async def _json_request(

--- a/src/telefire/memory_benchmark/backends.py
+++ b/src/telefire/memory_benchmark/backends.py
@@ -142,7 +142,7 @@ async def wait_for_hindsight_idle(
     base_url: str,
     bank_id: str,
     *,
-    timeout_seconds: float = 900,
+    timeout_seconds: float = 7_200,
 ) -> dict[str, Any]:
     encoded_bank = quote(bank_id, safe="")
     deadline = asyncio.get_running_loop().time() + timeout_seconds

--- a/src/telefire/memory_benchmark/cli.py
+++ b/src/telefire/memory_benchmark/cli.py
@@ -29,6 +29,7 @@ from telefire.memory_benchmark.evaluation import (
     write_cases,
 )
 from telefire.memory_benchmark.source import read_corpus, tencent_seed_payload
+from telefire.memory_benchmark.reporting import write_html_report
 
 
 def main() -> None:
@@ -68,6 +69,12 @@ def main() -> None:
     quality.add_argument("--judge-concurrency", type=int, default=2)
     quality.add_argument("--output", type=Path, required=True)
 
+    report = subparsers.add_parser("report")
+    report.add_argument("--quality", type=Path, required=True)
+    report.add_argument("--hindsight-ingest", type=Path, required=True)
+    report.add_argument("--tencent-seed", type=Path, required=True)
+    report.add_argument("--output", type=Path, required=True)
+
     args = parser.parse_args()
     asyncio.run(_dispatch(args))
 
@@ -94,6 +101,16 @@ async def _dispatch(args: argparse.Namespace) -> None:
         result = await seed_tencent(args.url, tencent_seed_payload(corpus))
         _write_json(args.output, result)
         print(json.dumps(result, ensure_ascii=False, indent=2))
+        return
+
+    if args.command == "report":
+        write_html_report(
+            args.quality,
+            args.hindsight_ingest,
+            args.tencent_seed,
+            args.output,
+        )
+        print(f"wrote report to {args.output}")
         return
 
     settings = _llm_settings(args.env_file, args.model, args.reasoning_effort)

--- a/src/telefire/memory_benchmark/cli.py
+++ b/src/telefire/memory_benchmark/cli.py
@@ -24,7 +24,7 @@ from telefire.memory_benchmark.backends import (
 from telefire.memory_benchmark.evaluation import (
     OpenAIJSONClient,
     generate_recall_cases,
-    grade_extraction_batch,
+    grade_extraction_resilient,
     grade_recall,
     read_cases,
     render_document,
@@ -264,7 +264,8 @@ async def _run_quality(
     _write_json(args.output, result)
 
     for backend, records in records_by_backend.items():
-        if backend in result.get("extraction", {}):
+        existing_extraction = result.get("extraction", {}).get(backend)
+        if existing_extraction and existing_extraction.get("complete") is True:
             print(f"using checkpointed {backend} extraction grades", flush=True)
             continue
         linked = tuple(
@@ -276,23 +277,41 @@ async def _run_quality(
         sample = sample_memory_records(linked, limit=args.extraction_sample)
         items = [_extraction_item(record, documents) for record in sample]
         batches = _item_batches(items, max_items=4, max_characters=28_000)
-        semaphore = asyncio.Semaphore(args.judge_concurrency)
-
-        async def grade(batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
-            async with semaphore:
-                return await grade_extraction_batch(client, batch)
-
-        print(
-            f"judging {backend} extraction: {len(sample)} memories in {len(batches)} batches",
-            flush=True,
-        )
-        groups = await asyncio.gather(*(grade(batch) for batch in batches))
-        grades = [item for group in groups for item in group]
-        result["extraction"][backend] = {
+        extraction = existing_extraction or {
             "sample_size": len(sample),
             "source_linked_population": len(linked),
-            "grades": grades,
+            "complete": False,
+            "grades": [],
         }
+        result["extraction"][backend] = extraction
+        completed_memory_ids = {
+            grade["memory_id"] for grade in extraction.get("grades", [])
+        }
+        pending_batches = [
+            [item for item in batch if item["memory_id"] not in completed_memory_ids]
+            for batch in batches
+        ]
+        pending_batches = [batch for batch in pending_batches if batch]
+        print(
+            f"judging {backend} extraction: {len(sample)} memories, "
+            f"{len(pending_batches)} pending batches",
+            flush=True,
+        )
+        for start in range(0, len(pending_batches), args.judge_concurrency):
+            wave = pending_batches[start : start + args.judge_concurrency]
+            groups = await asyncio.gather(
+                *(grade_extraction_resilient(client, batch) for batch in wave)
+            )
+            extraction["grades"].extend(
+                grade for group in groups for grade in group
+            )
+            _write_json(args.output, result)
+            print(
+                f"{backend} extraction batches "
+                f"{min(start + len(wave), len(pending_batches))}/{len(pending_batches)}",
+                flush=True,
+            )
+        extraction["complete"] = True
         _write_json(args.output, result)
 
     completed_case_ids = {

--- a/src/telefire/memory_benchmark/cli.py
+++ b/src/telefire/memory_benchmark/cli.py
@@ -223,6 +223,7 @@ async def _run_quality(
     tencent_records = read_tencent_memories(
         args.tencent_db,
         records_directory=args.tencent_records,
+        corpus=corpus,
     )
     records_by_backend = {
         "hindsight": hindsight_records,

--- a/src/telefire/memory_benchmark/cli.py
+++ b/src/telefire/memory_benchmark/cli.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections import Counter
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from telefire.memory_benchmark.backends import (
+    MemoryRecord,
+    ingest_hindsight,
+    list_hindsight_memories,
+    read_tencent_memories,
+    recall_hindsight,
+    recall_tencent,
+    seed_tencent,
+)
+from telefire.memory_benchmark.evaluation import (
+    OpenAIJSONClient,
+    generate_recall_cases,
+    grade_extraction_batch,
+    grade_recall,
+    read_cases,
+    render_document,
+    sample_memory_records,
+    write_cases,
+)
+from telefire.memory_benchmark.source import read_corpus, tencent_seed_payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark chat-memory backends")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    hindsight = subparsers.add_parser("ingest-hindsight")
+    hindsight.add_argument("--source", type=Path, required=True)
+    hindsight.add_argument("--url", required=True)
+    hindsight.add_argument("--bank", required=True)
+    hindsight.add_argument("--name", required=True)
+    hindsight.add_argument("--output", type=Path, required=True)
+    hindsight.add_argument("--batch-size", type=int, default=4)
+
+    tencent = subparsers.add_parser("seed-tencent")
+    tencent.add_argument("--source", type=Path, required=True)
+    tencent.add_argument("--url", required=True)
+    tencent.add_argument("--output", type=Path, required=True)
+
+    cases = subparsers.add_parser("generate-cases")
+    _add_llm_arguments(cases)
+    cases.add_argument("--source", type=Path, required=True)
+    cases.add_argument("--output", type=Path, required=True)
+    cases.add_argument("--target", type=int, default=60)
+    cases.add_argument("--concurrency", type=int, default=3)
+
+    quality = subparsers.add_parser("quality")
+    _add_llm_arguments(quality)
+    quality.add_argument("--source", type=Path, required=True)
+    quality.add_argument("--cases", type=Path, required=True)
+    quality.add_argument("--hindsight-url", required=True)
+    quality.add_argument("--hindsight-bank", required=True)
+    quality.add_argument("--tencent-url", required=True)
+    quality.add_argument("--tencent-db", type=Path, required=True)
+    quality.add_argument("--tencent-records", type=Path, required=True)
+    quality.add_argument("--extraction-sample", type=int, default=160)
+    quality.add_argument("--judge-concurrency", type=int, default=2)
+    quality.add_argument("--output", type=Path, required=True)
+
+    args = parser.parse_args()
+    asyncio.run(_dispatch(args))
+
+
+async def _dispatch(args: argparse.Namespace) -> None:
+    if args.command == "ingest-hindsight":
+        corpus = read_corpus(args.source)
+        result = await ingest_hindsight(
+            args.url,
+            args.bank,
+            args.name,
+            corpus,
+            batch_size=args.batch_size,
+            progress=lambda completed, total: print(
+                f"hindsight documents {completed}/{total}", flush=True
+            ),
+        )
+        _write_json(args.output, result)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return
+
+    if args.command == "seed-tencent":
+        corpus = read_corpus(args.source)
+        result = await seed_tencent(args.url, tencent_seed_payload(corpus))
+        _write_json(args.output, result)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return
+
+    settings = _llm_settings(args.env_file, args.model, args.reasoning_effort)
+    client = OpenAIJSONClient(**settings)
+    try:
+        if args.command == "generate-cases":
+            corpus = read_corpus(args.source)
+            generated = await generate_recall_cases(
+                corpus,
+                client,
+                target=args.target,
+                concurrency=args.concurrency,
+            )
+            write_cases(generated, args.output)
+            print(f"wrote {len(generated)} validated cases to {args.output}")
+        elif args.command == "quality":
+            await _run_quality(args, client)
+        else:
+            raise ValueError(f"Unknown command: {args.command}")
+    finally:
+        await client.close()
+
+
+async def _run_quality(
+    args: argparse.Namespace,
+    client: OpenAIJSONClient,
+) -> None:
+    started = perf_counter()
+    corpus = read_corpus(args.source)
+    documents = {document.document_id: document for document in corpus.documents}
+    cases = read_cases(args.cases)
+
+    print("loading normalized memory inventories", flush=True)
+    hindsight_records = await list_hindsight_memories(
+        args.hindsight_url,
+        args.hindsight_bank,
+        backend="hindsight",
+    )
+    tencent_records = read_tencent_memories(
+        args.tencent_db,
+        records_directory=args.tencent_records,
+    )
+    records_by_backend = {
+        "hindsight": hindsight_records,
+        "tencent": tencent_records,
+    }
+    result: dict[str, Any] = {
+        "schema": "telefire.memory-benchmark.quality.v1",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "judge_model": client.model,
+        "source": {
+            "bank_id": corpus.bank_id,
+            "documents": len(corpus.documents),
+            "events": len(corpus.events),
+        },
+        "inventories": {
+            backend: _inventory(records) for backend, records in records_by_backend.items()
+        },
+        "extraction": {},
+        "recall": [],
+    }
+    _write_json(args.output, result)
+
+    for backend, records in records_by_backend.items():
+        linked = tuple(
+            record
+            for record in records
+            if record.source_document_ids
+            and all(document_id in documents for document_id in record.source_document_ids)
+        )
+        sample = sample_memory_records(linked, limit=args.extraction_sample)
+        items = [_extraction_item(record, documents) for record in sample]
+        batches = _item_batches(items, max_items=4, max_characters=28_000)
+        semaphore = asyncio.Semaphore(args.judge_concurrency)
+
+        async def grade(batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            async with semaphore:
+                return await grade_extraction_batch(client, batch)
+
+        print(
+            f"judging {backend} extraction: {len(sample)} memories in {len(batches)} batches",
+            flush=True,
+        )
+        groups = await asyncio.gather(*(grade(batch) for batch in batches))
+        grades = [item for group in groups for item in group]
+        result["extraction"][backend] = {
+            "sample_size": len(sample),
+            "source_linked_population": len(linked),
+            "grades": grades,
+        }
+        _write_json(args.output, result)
+
+    if cases:
+        await recall_hindsight(
+            args.hindsight_url,
+            args.hindsight_bank,
+            cases[0].question,
+            backend="hindsight",
+        )
+        await recall_tencent(args.tencent_url, cases[0].question)
+
+    for index, case in enumerate(cases, start=1):
+        hindsight = await recall_hindsight(
+            args.hindsight_url,
+            args.hindsight_bank,
+            case.question,
+            backend="hindsight",
+        )
+        tencent = await recall_tencent(args.tencent_url, case.question)
+        measurements = {
+            "hindsight": hindsight,
+            "tencent": tencent,
+        }
+        grades = await grade_recall(
+            client,
+            case,
+            {backend: measurement.raw_context for backend, measurement in measurements.items()},
+        )
+        result["recall"].append(
+            {
+                "case": case.to_dict(),
+                "measurements": {
+                    backend: measurement.to_dict()
+                    for backend, measurement in measurements.items()
+                },
+                "grades": grades,
+            }
+        )
+        result["elapsed_seconds"] = perf_counter() - started
+        _write_json(args.output, result)
+        print(f"recall cases {index}/{len(cases)}", flush=True)
+
+    result["elapsed_seconds"] = perf_counter() - started
+    _write_json(args.output, result)
+    print(f"quality evaluation complete in {result['elapsed_seconds']:.1f}s", flush=True)
+
+
+def _add_llm_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--env-file", type=Path, required=True)
+    parser.add_argument("--model", default="gpt-5.4-mini")
+    parser.add_argument("--reasoning-effort", default="low")
+
+
+def _llm_settings(
+    env_file: Path,
+    model: str,
+    reasoning_effort: str,
+) -> dict[str, str]:
+    values = _read_env_file(env_file)
+    return {
+        "base_url": _required_env(values, "MEMORY_LLM_BASE_URL"),
+        "api_key": _required_env(values, "MEMORY_LLM_API_KEY"),
+        "model": model,
+        "reasoning_effort": reasoning_effort,
+    }
+
+
+def _read_env_file(path: Path) -> dict[str, str]:
+    values = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def _required_env(values: dict[str, str], name: str) -> str:
+    value = values.get(name)
+    if not value:
+        raise ValueError(f"Missing {name}")
+    return value
+
+
+def _inventory(records: tuple[MemoryRecord, ...]) -> dict[str, Any]:
+    return {
+        "total": len(records),
+        "source_linked": sum(bool(record.source_document_ids) for record in records),
+        "types": dict(sorted(Counter(record.memory_type for record in records).items())),
+    }
+
+
+def _extraction_item(
+    record: MemoryRecord,
+    documents: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "memory_id": record.memory_id,
+        "memory_type": record.memory_type,
+        "extracted_memory": record.text,
+        "source_evidence": [
+            render_document(documents[document_id])
+            for document_id in record.source_document_ids
+        ],
+    }
+
+
+def _item_batches(
+    items: list[dict[str, Any]],
+    *,
+    max_items: int,
+    max_characters: int,
+) -> list[list[dict[str, Any]]]:
+    batches: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+    current_size = 0
+    for item in items:
+        size = len(json.dumps(item, ensure_ascii=False))
+        if current and (len(current) >= max_items or current_size + size > max_characters):
+            batches.append(current)
+            current = []
+            current_size = 0
+        current.append(item)
+        current_size += size
+    if current:
+        batches.append(current)
+    return batches
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/telefire/memory_benchmark/cli.py
+++ b/src/telefire/memory_benchmark/cli.py
@@ -42,7 +42,8 @@ def main() -> None:
     hindsight.add_argument("--bank", required=True)
     hindsight.add_argument("--name", required=True)
     hindsight.add_argument("--output", type=Path, required=True)
-    hindsight.add_argument("--batch-size", type=int, default=4)
+    hindsight.add_argument("--batch-size", type=int, default=1)
+    hindsight.add_argument("--concurrency", type=int, default=4)
 
     tencent = subparsers.add_parser("seed-tencent")
     tencent.add_argument("--source", type=Path, required=True)
@@ -88,6 +89,7 @@ async def _dispatch(args: argparse.Namespace) -> None:
             args.name,
             corpus,
             batch_size=args.batch_size,
+            concurrency=args.concurrency,
             progress=lambda completed, total: print(
                 f"hindsight documents {completed}/{total}", flush=True
             ),

--- a/src/telefire/memory_benchmark/cli.py
+++ b/src/telefire/memory_benchmark/cli.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any
 
+import aiohttp
+
 from telefire.memory_benchmark.backends import (
     MemoryRecord,
     ingest_hindsight,
@@ -17,6 +19,7 @@ from telefire.memory_benchmark.backends import (
     recall_hindsight,
     recall_tencent,
     seed_tencent,
+    wait_for_hindsight_idle,
 )
 from telefire.memory_benchmark.evaluation import (
     OpenAIJSONClient,
@@ -45,6 +48,15 @@ def main() -> None:
     hindsight.add_argument("--output", type=Path, required=True)
     hindsight.add_argument("--batch-size", type=int, default=1)
     hindsight.add_argument("--concurrency", type=int, default=4)
+
+    wait_hindsight = subparsers.add_parser("wait-hindsight")
+    wait_hindsight.add_argument("--url", required=True)
+    wait_hindsight.add_argument("--bank", required=True)
+    wait_hindsight.add_argument("--started-at", required=True)
+    wait_hindsight.add_argument("--documents", type=int, required=True)
+    wait_hindsight.add_argument("--batch-size", type=int, required=True)
+    wait_hindsight.add_argument("--concurrency", type=int, required=True)
+    wait_hindsight.add_argument("--output", type=Path, required=True)
 
     tencent = subparsers.add_parser("seed-tencent")
     tencent.add_argument("--source", type=Path, required=True)
@@ -110,6 +122,31 @@ async def _dispatch(args: argparse.Namespace) -> None:
     if args.command == "seed-tencent":
         corpus = read_corpus(args.source)
         result = await seed_tencent(args.url, tencent_seed_payload(corpus))
+        _write_json(args.output, result)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return
+
+    if args.command == "wait-hindsight":
+        started_at = datetime.fromisoformat(args.started_at.replace("Z", "+00:00"))
+        if started_at.tzinfo is None:
+            raise ValueError("--started-at must include a timezone")
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=7_300)) as session:
+            stats = await wait_for_hindsight_idle(
+                session,
+                args.url,
+                args.bank,
+                timeout_seconds=7_200,
+            )
+        result = {
+            "backend": "hindsight-fresh",
+            "elapsed_seconds": (datetime.now(UTC) - started_at.astimezone(UTC)).total_seconds(),
+            "documents": args.documents,
+            "batch_size": args.batch_size,
+            "concurrency": args.concurrency,
+            "operations": (args.documents + args.batch_size - 1) // args.batch_size,
+            "stats": stats,
+            "recovered_after_client_timeout": True,
+        }
         _write_json(args.output, result)
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return

--- a/src/telefire/memory_benchmark/cli.py
+++ b/src/telefire/memory_benchmark/cli.py
@@ -26,6 +26,7 @@ from telefire.memory_benchmark.evaluation import (
     read_cases,
     render_document,
     sample_memory_records,
+    semantically_validate_cases,
     write_cases,
 )
 from telefire.memory_benchmark.source import read_corpus, tencent_seed_payload
@@ -56,6 +57,14 @@ def main() -> None:
     cases.add_argument("--output", type=Path, required=True)
     cases.add_argument("--target", type=int, default=60)
     cases.add_argument("--concurrency", type=int, default=3)
+
+    validate_cases = subparsers.add_parser("validate-cases")
+    _add_llm_arguments(validate_cases)
+    validate_cases.add_argument("--source", type=Path, required=True)
+    validate_cases.add_argument("--cases", type=Path, required=True)
+    validate_cases.add_argument("--output", type=Path, required=True)
+    validate_cases.add_argument("--audit-output", type=Path, required=True)
+    validate_cases.add_argument("--concurrency", type=int, default=2)
 
     quality = subparsers.add_parser("quality")
     _add_llm_arguments(quality)
@@ -128,6 +137,29 @@ async def _dispatch(args: argparse.Namespace) -> None:
             )
             write_cases(generated, args.output)
             print(f"wrote {len(generated)} validated cases to {args.output}")
+        elif args.command == "validate-cases":
+            corpus = read_corpus(args.source)
+            supplied_cases = read_cases(args.cases)
+            accepted, reviews = await semantically_validate_cases(
+                corpus,
+                supplied_cases,
+                client,
+                concurrency=args.concurrency,
+            )
+            write_cases(accepted, args.output)
+            _write_json(
+                args.audit_output,
+                {
+                    "schema": "telefire.memory-benchmark.case-validation.v1",
+                    "model": client.model,
+                    "input_cases": len(supplied_cases),
+                    "accepted_cases": len(accepted),
+                    "reviews": reviews,
+                },
+            )
+            print(
+                f"accepted {len(accepted)}/{len(supplied_cases)} cases into {args.output}"
+            )
         elif args.command == "quality":
             await _run_quality(args, client)
         else:

--- a/src/telefire/memory_benchmark/cli.py
+++ b/src/telefire/memory_benchmark/cli.py
@@ -191,24 +191,44 @@ async def _run_quality(
         "hindsight": hindsight_records,
         "tencent": tencent_records,
     }
-    result: dict[str, Any] = {
-        "schema": "telefire.memory-benchmark.quality.v1",
-        "generated_at": datetime.now(UTC).isoformat(),
-        "judge_model": client.model,
-        "source": {
-            "bank_id": corpus.bank_id,
-            "documents": len(corpus.documents),
-            "events": len(corpus.events),
-        },
-        "inventories": {
+    if args.output.exists():
+        result = _read_json(args.output)
+        if (
+            result.get("schema") != "telefire.memory-benchmark.quality.v1"
+            or result.get("judge_model") != client.model
+            or result.get("source", {}).get("bank_id") != corpus.bank_id
+        ):
+            raise ValueError("Existing quality checkpoint does not match this run")
+        result["inventories"] = {
             backend: _inventory(records) for backend, records in records_by_backend.items()
-        },
-        "extraction": {},
-        "recall": [],
-    }
+        }
+        print(
+            f"resuming quality checkpoint with {len(result.get('recall', []))} recall cases",
+            flush=True,
+        )
+    else:
+        result = {
+            "schema": "telefire.memory-benchmark.quality.v1",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "judge_model": client.model,
+            "source": {
+                "bank_id": corpus.bank_id,
+                "documents": len(corpus.documents),
+                "events": len(corpus.events),
+            },
+            "inventories": {
+                backend: _inventory(records)
+                for backend, records in records_by_backend.items()
+            },
+            "extraction": {},
+            "recall": [],
+        }
     _write_json(args.output, result)
 
     for backend, records in records_by_backend.items():
+        if backend in result.get("extraction", {}):
+            print(f"using checkpointed {backend} extraction grades", flush=True)
+            continue
         linked = tuple(
             record
             for record in records
@@ -237,16 +257,20 @@ async def _run_quality(
         }
         _write_json(args.output, result)
 
-    if cases:
+    completed_case_ids = {
+        row["case"]["case_id"] for row in result.get("recall", [])
+    }
+    remaining_cases = [case for case in cases if case.case_id not in completed_case_ids]
+    if remaining_cases:
         await recall_hindsight(
             args.hindsight_url,
             args.hindsight_bank,
-            cases[0].question,
+            remaining_cases[0].question,
             backend="hindsight",
         )
-        await recall_tencent(args.tencent_url, cases[0].question)
+        await recall_tencent(args.tencent_url, remaining_cases[0].question)
 
-    for index, case in enumerate(cases, start=1):
+    for index, case in enumerate(remaining_cases, start=1):
         hindsight = await recall_hindsight(
             args.hindsight_url,
             args.hindsight_bank,
@@ -275,7 +299,10 @@ async def _run_quality(
         )
         result["elapsed_seconds"] = perf_counter() - started
         _write_json(args.output, result)
-        print(f"recall cases {index}/{len(cases)}", flush=True)
+        print(
+            f"recall cases {len(completed_case_ids) + index}/{len(cases)}",
+            flush=True,
+        )
 
     result["elapsed_seconds"] = perf_counter() - started
     _write_json(args.output, result)
@@ -373,6 +400,13 @@ def _write_json(path: Path, value: dict[str, Any]) -> None:
         encoding="utf-8",
     )
     temporary.replace(path)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return value
 
 
 if __name__ == "__main__":

--- a/src/telefire/memory_benchmark/evaluation.py
+++ b/src/telefire/memory_benchmark/evaluation.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict, dataclass
+import hashlib
+from itertools import zip_longest
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from openai import AsyncOpenAI
+
+from telefire.memory_benchmark.backends import MemoryRecord
+from telefire.memory_benchmark.source import SourceCorpus, SourceDocument
+
+
+_CASE_CATEGORIES = {
+    "direct",
+    "identity_alias",
+    "relationship",
+    "temporal",
+    "preference",
+    "project",
+    "multi_document",
+}
+_LINKED_CATEGORIES = {"identity_alias", "relationship", "multi_document"}
+
+
+@dataclass(frozen=True, slots=True)
+class Evidence:
+    document_id: str
+    quote: str
+
+
+@dataclass(frozen=True, slots=True)
+class RecallCase:
+    case_id: str
+    category: str
+    question: str
+    answer: str
+    evidence: tuple[Evidence, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> RecallCase:
+        supplied = dict(value)
+        evidence = tuple(Evidence(**item) for item in supplied.pop("evidence"))
+        return cls(evidence=evidence, **supplied)
+
+
+class OpenAIJSONClient:
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        model: str,
+        reasoning_effort: str = "low",
+    ) -> None:
+        self.model = model
+        self.reasoning_effort = reasoning_effort
+        self._client = AsyncOpenAI(base_url=base_url, api_key=api_key, timeout=180)
+
+    async def close(self) -> None:
+        await self._client.close()
+
+    async def complete_json(
+        self,
+        *,
+        system: str,
+        prompt: str,
+        max_completion_tokens: int = 5_000,
+    ) -> dict[str, Any]:
+        latest_error: Exception | None = None
+        for attempt in range(3):
+            try:
+                response = await self._client.chat.completions.create(
+                    model=self.model,
+                    messages=[
+                        {"role": "system", "content": system},
+                        {"role": "user", "content": prompt},
+                    ],
+                    response_format={"type": "json_object"},
+                    max_completion_tokens=max_completion_tokens,
+                    reasoning_effort=self.reasoning_effort,
+                )
+                content = response.choices[0].message.content
+                if not isinstance(content, str):
+                    raise ValueError("Judge returned an empty response")
+                return parse_json_object(content)
+            except Exception as exc:
+                latest_error = exc
+                if attempt < 2:
+                    await asyncio.sleep(2**attempt)
+        assert latest_error is not None
+        raise latest_error
+
+
+def parse_json_object(value: str) -> dict[str, Any]:
+    stripped = value.strip()
+    if stripped.startswith("```"):
+        first_newline = stripped.find("\n")
+        stripped = stripped[first_newline + 1 :] if first_newline >= 0 else stripped
+        if stripped.endswith("```"):
+            stripped = stripped[:-3]
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start < 0 or end < start:
+        raise ValueError("LLM response does not contain a JSON object")
+    parsed = json.loads(stripped[start : end + 1])
+    if not isinstance(parsed, dict):
+        raise ValueError("LLM response is not a JSON object")
+    return parsed
+
+
+def render_document(document: SourceDocument) -> str:
+    lines = [f"[Document: {document.document_id}]"]
+    lines.extend(
+        f"[{event.occurred_at}] {event.actor_name} ({event.actor_id}): {event.text}"
+        for event in document.events
+    )
+    return "\n".join(lines)
+
+
+def validate_recall_case(
+    supplied: Any,
+    documents: dict[str, SourceDocument],
+) -> RecallCase | None:
+    if not isinstance(supplied, dict):
+        return None
+    category = supplied.get("category")
+    question = supplied.get("question")
+    answer = supplied.get("answer")
+    evidence_items = supplied.get("evidence")
+    if (
+        category not in _CASE_CATEGORIES
+        or not isinstance(question, str)
+        or len(question.strip()) < 4
+        or not isinstance(answer, str)
+        or len(answer.strip()) < 1
+        or not isinstance(evidence_items, list)
+        or not evidence_items
+    ):
+        return None
+
+    evidence = []
+    for item in evidence_items:
+        if not isinstance(item, dict):
+            return None
+        document_id = item.get("document_id")
+        quote = item.get("quote")
+        document = documents.get(document_id) if isinstance(document_id, str) else None
+        if (
+            document is None
+            or not isinstance(quote, str)
+            or len(quote.strip()) < 2
+            or not any(quote in event.text for event in document.events)
+        ):
+            return None
+        evidence.append(Evidence(document_id=document_id, quote=quote))
+
+    normalized_question = question.strip()
+    normalized_answer = answer.strip()
+    fingerprint = json.dumps(
+        [normalized_question, normalized_answer, [asdict(item) for item in evidence]],
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+    case_id = hashlib.sha256(fingerprint.encode()).hexdigest()[:16]
+    return RecallCase(
+        case_id=case_id,
+        category=category,
+        question=normalized_question,
+        answer=normalized_answer,
+        evidence=tuple(evidence),
+    )
+
+
+async def generate_recall_cases(
+    corpus: SourceCorpus,
+    client: OpenAIJSONClient,
+    *,
+    target: int = 60,
+    concurrency: int = 3,
+) -> tuple[RecallCase, ...]:
+    documents = {document.document_id: document for document in corpus.documents}
+    packs = _generation_packs(corpus)
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def generate(mode: str, pack: tuple[SourceDocument, ...]) -> list[RecallCase]:
+        prompt = _generation_prompt(mode, pack)
+        async with semaphore:
+            response = await client.complete_json(
+                system=(
+                    "你是聊天记忆系统的独立评测集设计者。只根据提供的聊天原文创建问题，"
+                    "严格区分每位发言者，不得补充常识或猜测。输出合法 JSON。"
+                ),
+                prompt=prompt,
+            )
+        supplied_cases = response.get("cases")
+        if not isinstance(supplied_cases, list):
+            raise ValueError("Case generator returned malformed cases")
+        allowed_documents = {document.document_id for document in pack}
+        cases = []
+        for supplied in supplied_cases:
+            case = validate_recall_case(supplied, documents)
+            if case is not None and all(
+                evidence.document_id in allowed_documents for evidence in case.evidence
+            ):
+                cases.append(case)
+        return cases
+
+    generated = await asyncio.gather(
+        *(generate(mode, pack) for mode, pack in packs)
+    )
+    unique: dict[str, RecallCase] = {}
+    for case in (case for group in generated for case in group):
+        unique.setdefault(case.case_id, case)
+
+    linked = [case for case in unique.values() if case.category in _LINKED_CATEGORIES]
+    direct = [case for case in unique.values() if case.category not in _LINKED_CATEGORIES]
+    linked_target = min(len(linked), max(1, target // 4))
+    selected = linked[:linked_target] + direct[: target - linked_target]
+    if len(selected) < target:
+        selected_ids = {case.case_id for case in selected}
+        selected.extend(
+            case
+            for case in unique.values()
+            if case.case_id not in selected_ids
+        )
+    if len(selected) < target:
+        raise RuntimeError(
+            f"Generated only {len(selected)} validated recall cases; expected {target}"
+        )
+    return tuple(selected[:target])
+
+
+async def grade_recall(
+    client: OpenAIJSONClient,
+    case: RecallCase,
+    contexts: dict[str, str],
+) -> dict[str, dict[str, Any]]:
+    backends = sorted(contexts)
+    if int(case.case_id[-1], 16) % 2:
+        backends.reverse()
+    labels = {chr(65 + index): backend for index, backend in enumerate(backends)}
+    payload = {
+        "question": case.question,
+        "reference_answer": case.answer,
+        "source_evidence": [asdict(item) for item in case.evidence],
+        "retrieved_contexts": {
+            label: contexts[backend][:20_000] for label, backend in labels.items()
+        },
+    }
+    response = await client.complete_json(
+        system=(
+            "你是记忆检索评测裁判。根据参考答案和原始证据，独立判断每个匿名检索上下文"
+            "是否足以回答问题。不要因为措辞不同扣分，也不要使用外部知识。输出合法 JSON。"
+        ),
+        prompt=(
+            "请为每个上下文评分并返回："
+            '{"grades":[{"label":"A","answer_coverage":0到4,'
+            '"attribution":0到4,"temporal":0到4或null,'
+            '"contradiction":true或false,"reason":"简短理由"}]}。\n'
+            "answer_coverage: 0=无相关信息，2=部分可答，3=基本可答，4=完整准确；"
+            "attribution: 是否归属正确的人；temporal: 涉及时序时评分，否则 null；"
+            "contradiction: 上下文是否包含会导致错误答案的矛盾信息。\n\n"
+            + json.dumps(payload, ensure_ascii=False)
+        ),
+        max_completion_tokens=2_500,
+    )
+    supplied_grades = response.get("grades")
+    if not isinstance(supplied_grades, list):
+        raise ValueError("Recall judge returned malformed grades")
+    result = {}
+    for grade in supplied_grades:
+        if not isinstance(grade, dict) or grade.get("label") not in labels:
+            continue
+        result[labels[grade["label"]]] = _validated_recall_grade(grade)
+    if set(result) != set(backends):
+        raise ValueError("Recall judge omitted a backend")
+    return result
+
+
+async def grade_extraction_batch(
+    client: OpenAIJSONClient,
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    response = await client.complete_json(
+        system=(
+            "你是记忆抽取质量评测裁判。逐条比较抽取记忆与其原始聊天证据，严格区分"
+            "不同发言者，不使用外部知识。输出合法 JSON。"
+        ),
+        prompt=(
+            "请返回："
+            '{"grades":[{"memory_id":"...","faithfulness":0到4,'
+            '"attribution":0到4,"specificity":0到4,"usefulness":0到4,'
+            '"temporal":0到4或null,"unsupported_claim":true或false,'
+            '"overcombined":true或false,"reason":"简短理由"}]}。\n'
+            "faithfulness 衡量是否被原文支持；attribution 衡量是否归属正确的人；"
+            "specificity 衡量是否保留关键限定；usefulness 衡量未来回忆价值；"
+            "temporal 仅在有时间信息时评分；unsupported_claim 表示含无证据主张；"
+            "overcombined 表示错误合并了不同人物或事件。\n\n"
+            + json.dumps({"items": items}, ensure_ascii=False)
+        ),
+        max_completion_tokens=4_000,
+    )
+    supplied_grades = response.get("grades")
+    if not isinstance(supplied_grades, list):
+        raise ValueError("Extraction judge returned malformed grades")
+    expected = {item["memory_id"] for item in items}
+    grades = []
+    for grade in supplied_grades:
+        if not isinstance(grade, dict) or grade.get("memory_id") not in expected:
+            continue
+        grades.append(_validated_extraction_grade(grade))
+    if {grade["memory_id"] for grade in grades} != expected:
+        raise ValueError("Extraction judge omitted a memory")
+    return grades
+
+
+def sample_memory_records(
+    records: Iterable[MemoryRecord],
+    *,
+    limit: int,
+) -> tuple[MemoryRecord, ...]:
+    groups: dict[str, list[MemoryRecord]] = {}
+    for record in records:
+        groups.setdefault(record.memory_type, []).append(record)
+    for group in groups.values():
+        group.sort(key=lambda record: hashlib.sha256(record.memory_id.encode()).hexdigest())
+
+    selected = []
+    group_names = sorted(groups)
+    while len(selected) < limit:
+        progressed = False
+        for name in group_names:
+            if groups[name]:
+                selected.append(groups[name].pop(0))
+                progressed = True
+                if len(selected) == limit:
+                    break
+        if not progressed:
+            break
+    return tuple(selected)
+
+
+def write_cases(cases: Iterable[RecallCase], path: Path) -> None:
+    _write_json(
+        path,
+        {
+            "schema": "telefire.memory-benchmark.recall-cases.v1",
+            "cases": [case.to_dict() for case in cases],
+        },
+    )
+
+
+def read_cases(path: Path) -> tuple[RecallCase, ...]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if value.get("schema") != "telefire.memory-benchmark.recall-cases.v1":
+        raise ValueError("Unsupported recall case schema")
+    return tuple(RecallCase.from_dict(item) for item in value["cases"])
+
+
+def _generation_packs(
+    corpus: SourceCorpus,
+) -> list[tuple[str, tuple[SourceDocument, ...]]]:
+    direct_documents = _spread(corpus.documents, min(144, len(corpus.documents)))
+    direct = [("direct", pack) for pack in _pack_documents(direct_documents)]
+
+    actor_documents: dict[str, list[SourceDocument]] = {}
+    for document in corpus.documents:
+        for actor_id in {event.actor_id for event in document.events}:
+            actor_documents.setdefault(actor_id, []).append(document)
+    eligible = sorted(
+        (documents for documents in actor_documents.values() if len(documents) >= 3),
+        key=lambda documents: (-len(documents), documents[0].document_id),
+    )[:18]
+    linked = [
+        ("linked", tuple(_spread(tuple(documents), min(4, len(documents)))))
+        for documents in eligible
+    ]
+
+    interleaved = []
+    for direct_item, linked_item in zip_longest(direct, linked):
+        if direct_item is not None:
+            interleaved.append(direct_item)
+        if linked_item is not None:
+            interleaved.append(linked_item)
+    return interleaved
+
+
+def _pack_documents(
+    documents: tuple[SourceDocument, ...],
+    *,
+    max_documents: int = 6,
+    max_characters: int = 26_000,
+) -> list[tuple[SourceDocument, ...]]:
+    packs: list[tuple[SourceDocument, ...]] = []
+    current: list[SourceDocument] = []
+    current_characters = 0
+    for document in documents:
+        size = len(render_document(document))
+        if current and (
+            len(current) >= max_documents or current_characters + size > max_characters
+        ):
+            packs.append(tuple(current))
+            current = []
+            current_characters = 0
+        current.append(document)
+        current_characters += size
+    if current:
+        packs.append(tuple(current))
+    return packs
+
+
+def _generation_prompt(mode: str, documents: tuple[SourceDocument, ...]) -> str:
+    focus = (
+        "优先创建需要联系多段记录的身份、别名、关系或时间变化问题。"
+        if mode == "linked"
+        else "创建 1 到 3 个可由原文明确回答、未来回忆时有价值的问题。"
+    )
+    return (
+        f"{focus}\n"
+        "不要为寒暄、表情、一次性命令创建问题。问题中使用自然姓名，不暴露内部 ID。"
+        "每条 evidence.quote 必须逐字复制某一条消息中的连续文本，不得改写。"
+        "若没有合格事实，cases 返回空数组。输出格式："
+        '{"cases":[{"category":"direct|identity_alias|relationship|temporal|preference|project|multi_document",'
+        '"question":"...","answer":"...","evidence":[{"document_id":"...","quote":"原文"}]}]}。\n\n'
+        + "\n\n".join(render_document(document) for document in documents)
+    )
+
+
+def _spread(values: tuple[Any, ...], count: int) -> tuple[Any, ...]:
+    if count >= len(values):
+        return values
+    if count <= 1:
+        return values[:count]
+    indexes = {
+        round(index * (len(values) - 1) / (count - 1)) for index in range(count)
+    }
+    return tuple(values[index] for index in sorted(indexes))
+
+
+def _validated_recall_grade(value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "answer_coverage": _score(value, "answer_coverage"),
+        "attribution": _score(value, "attribution"),
+        "temporal": _optional_score(value, "temporal"),
+        "contradiction": _boolean(value, "contradiction"),
+        "reason": str(value.get("reason") or ""),
+    }
+
+
+def _validated_extraction_grade(value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "memory_id": str(value["memory_id"]),
+        "faithfulness": _score(value, "faithfulness"),
+        "attribution": _score(value, "attribution"),
+        "specificity": _score(value, "specificity"),
+        "usefulness": _score(value, "usefulness"),
+        "temporal": _optional_score(value, "temporal"),
+        "unsupported_claim": _boolean(value, "unsupported_claim"),
+        "overcombined": _boolean(value, "overcombined"),
+        "reason": str(value.get("reason") or ""),
+    }
+
+
+def _score(value: dict[str, Any], name: str) -> int:
+    score = value.get(name)
+    if not isinstance(score, int) or isinstance(score, bool) or not 0 <= score <= 4:
+        raise ValueError(f"Invalid {name} score")
+    return score
+
+
+def _optional_score(value: dict[str, Any], name: str) -> int | None:
+    score = value.get(name)
+    return None if score is None else _score(value, name)
+
+
+def _boolean(value: dict[str, Any], name: str) -> bool:
+    supplied = value.get(name)
+    if not isinstance(supplied, bool):
+        raise ValueError(f"Invalid {name}")
+    return supplied
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    temporary.replace(path)

--- a/src/telefire/memory_benchmark/evaluation.py
+++ b/src/telefire/memory_benchmark/evaluation.py
@@ -242,6 +242,33 @@ async def grade_recall(
     case: RecallCase,
     contexts: dict[str, str],
 ) -> dict[str, dict[str, Any]]:
+    try:
+        return await _grade_recall_once(client, case, contexts)
+    except ValueError:
+        await asyncio.sleep(1)
+        try:
+            return await _grade_recall_once(client, case, contexts)
+        except ValueError:
+            if len(contexts) == 1:
+                raise
+            groups = await asyncio.gather(
+                *(
+                    _grade_recall_once(client, case, {backend: context})
+                    for backend, context in contexts.items()
+                )
+            )
+            return {
+                backend: grade
+                for group in groups
+                for backend, grade in group.items()
+            }
+
+
+async def _grade_recall_once(
+    client: OpenAIJSONClient,
+    case: RecallCase,
+    contexts: dict[str, str],
+) -> dict[str, dict[str, Any]]:
     backends = sorted(contexts)
     if int(case.case_id[-1], 16) % 2:
         backends.reverse()
@@ -409,6 +436,24 @@ async def grade_extraction_batch(
     if {grade["memory_id"] for grade in grades} != expected:
         raise ValueError("Extraction judge omitted a memory")
     return grades
+
+
+async def grade_extraction_resilient(
+    client: OpenAIJSONClient,
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    try:
+        return await grade_extraction_batch(client, items)
+    except ValueError:
+        if len(items) == 1:
+            await asyncio.sleep(1)
+            return await grade_extraction_batch(client, items)
+        midpoint = len(items) // 2
+        left, right = await asyncio.gather(
+            grade_extraction_resilient(client, items[:midpoint]),
+            grade_extraction_resilient(client, items[midpoint:]),
+        )
+        return left + right
 
 
 def sample_memory_records(

--- a/src/telefire/memory_benchmark/evaluation.py
+++ b/src/telefire/memory_benchmark/evaluation.py
@@ -284,6 +284,96 @@ async def grade_recall(
     return result
 
 
+async def semantically_validate_cases(
+    corpus: SourceCorpus,
+    cases: tuple[RecallCase, ...],
+    client: OpenAIJSONClient,
+    *,
+    concurrency: int = 2,
+) -> tuple[tuple[RecallCase, ...], list[dict[str, Any]]]:
+    documents = {document.document_id: document for document in corpus.documents}
+    items = []
+    for case in cases:
+        source_documents = tuple(
+            dict.fromkeys(evidence.document_id for evidence in case.evidence)
+        )
+        items.append(
+            {
+                "case_id": case.case_id,
+                "question": case.question,
+                "answer": case.answer,
+                "cited_evidence": [asdict(evidence) for evidence in case.evidence],
+                "source_context": [
+                    render_document(documents[document_id])
+                    for document_id in source_documents
+                ],
+            }
+        )
+    batches = _bounded_item_batches(items, max_items=5, max_characters=30_000)
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def validate(batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        async with semaphore:
+            response = await client.complete_json(
+                system=(
+                    "你是聊天记忆评测集的独立审核员。只依据原始聊天上下文，严格检查"
+                    "问题是否清楚、答案是否完整且归属到正确发言者。输出合法 JSON。"
+                ),
+                prompt=(
+                    "逐条审核并返回："
+                    '{"reviews":[{"case_id":"...","valid":true或false,'
+                    '"reason":"简短理由"}]}。只有问题无歧义、答案完全被原文支持、人物归属和'
+                    "时间关系均正确时 valid 才能为 true。不要用外部知识。\n\n"
+                    + json.dumps({"cases": batch}, ensure_ascii=False)
+                ),
+                max_completion_tokens=3_000,
+            )
+        reviews = response.get("reviews")
+        if not isinstance(reviews, list):
+            raise ValueError("Case validator returned malformed reviews")
+        expected = {item["case_id"] for item in batch}
+        normalized = []
+        for review in reviews:
+            if not isinstance(review, dict) or review.get("case_id") not in expected:
+                continue
+            valid = review.get("valid")
+            if not isinstance(valid, bool):
+                raise ValueError("Case validator returned invalid verdict")
+            normalized.append(
+                {
+                    "case_id": review["case_id"],
+                    "valid": valid,
+                    "reason": str(review.get("reason") or ""),
+                }
+            )
+        if {review["case_id"] for review in normalized} != expected:
+            raise ValueError("Case validator omitted a case")
+        return normalized
+
+    reviewed = await asyncio.gather(*(validate(batch) for batch in batches))
+    reviews = [review for group in reviewed for review in group]
+    return filter_validated_cases(cases, reviews), reviews
+
+
+def filter_validated_cases(
+    cases: tuple[RecallCase, ...],
+    reviews: list[dict[str, Any]],
+) -> tuple[RecallCase, ...]:
+    verdicts: dict[str, bool] = {}
+    for review in reviews:
+        case_id = review.get("case_id")
+        valid = review.get("valid")
+        if not isinstance(case_id, str) or not isinstance(valid, bool):
+            raise ValueError("Malformed semantic case review")
+        if case_id in verdicts:
+            raise ValueError(f"Duplicate semantic review for {case_id}")
+        verdicts[case_id] = valid
+    missing = {case.case_id for case in cases} - set(verdicts)
+    if missing:
+        raise ValueError(f"Missing semantic reviews for {len(missing)} cases")
+    return tuple(case for case in cases if verdicts[case.case_id])
+
+
 async def grade_extraction_batch(
     client: OpenAIJSONClient,
     items: list[dict[str, Any]],
@@ -414,6 +504,28 @@ def _pack_documents(
     if current:
         packs.append(tuple(current))
     return packs
+
+
+def _bounded_item_batches(
+    items: list[dict[str, Any]],
+    *,
+    max_items: int,
+    max_characters: int,
+) -> list[list[dict[str, Any]]]:
+    batches: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+    current_size = 0
+    for item in items:
+        size = len(json.dumps(item, ensure_ascii=False))
+        if current and (len(current) >= max_items or current_size + size > max_characters):
+            batches.append(current)
+            current = []
+            current_size = 0
+        current.append(item)
+        current_size += size
+    if current:
+        batches.append(current)
+    return batches
 
 
 def _generation_prompt(mode: str, documents: tuple[SourceDocument, ...]) -> str:

--- a/src/telefire/memory_benchmark/reporting.py
+++ b/src/telefire/memory_benchmark/reporting.py
@@ -155,7 +155,7 @@ code {{ overflow-wrap:anywhere; }}
   <div class="table-wrap"><table>
     <thead><tr><th>Backend</th><th>Input episodes</th><th>Wall time</th><th>Episodes / minute</th><th>Notes</th></tr></thead>
     <tbody>
-      {_ingest_row('Hindsight', hindsight_ingest.get('documents', 0), hindsight_ingest.get('elapsed_seconds', 0), 'Synchronous retain, batch size 4')}
+      {_ingest_row('Hindsight', hindsight_ingest.get('documents', 0), hindsight_ingest.get('elapsed_seconds', 0), f"Synchronous retain, batch size {hindsight_ingest.get('batch_size', 'unknown')}")}
       {_ingest_row('Tencent', _tencent_rounds(tencent_seed), tencent_seed.get('elapsed_seconds_client', 0), 'One round per source episode; L1 every 5 rounds')}
     </tbody>
   </table></div>

--- a/src/telefire/memory_benchmark/reporting.py
+++ b/src/telefire/memory_benchmark/reporting.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import UTC, datetime
+from html import escape
+import json
+import math
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+
+def summarize_quality(quality: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    backends = sorted(quality.get("inventories", {}))
+    summary: dict[str, dict[str, Any]] = {}
+    for backend in backends:
+        inventory = quality["inventories"][backend]
+        extraction = quality.get("extraction", {}).get(backend, {})
+        extraction_grades = extraction.get("grades", [])
+        recall_rows = [
+            row for row in quality.get("recall", []) if backend in row.get("grades", {})
+        ]
+        recall_grades = [row["grades"][backend] for row in recall_rows]
+        latency = [row["measurements"][backend]["elapsed_ms"] for row in recall_rows]
+        total = inventory.get("total", 0)
+        summary[backend] = {
+            "memories": total,
+            "types": inventory.get("types", {}),
+            "source_link_rate": inventory.get("source_linked", 0) / total if total else 0.0,
+            "extraction_sample": len(extraction_grades),
+            "faithfulness": _average(extraction_grades, "faithfulness"),
+            "extraction_attribution": _average(extraction_grades, "attribution"),
+            "specificity": _average(extraction_grades, "specificity"),
+            "usefulness": _average(extraction_grades, "usefulness"),
+            "unsupported_rate": _boolean_rate(extraction_grades, "unsupported_claim"),
+            "overcombined_rate": _boolean_rate(extraction_grades, "overcombined"),
+            "recall_cases": len(recall_grades),
+            "recall_coverage": _average(recall_grades, "answer_coverage"),
+            "recall_attribution": _average(recall_grades, "attribution"),
+            "recall_success_rate": (
+                sum(grade["answer_coverage"] >= 3 for grade in recall_grades)
+                / len(recall_grades)
+                if recall_grades
+                else 0.0
+            ),
+            "contradiction_rate": _boolean_rate(recall_grades, "contradiction"),
+            "latency_p50_ms": _percentile(latency, 0.50),
+            "latency_p95_ms": _percentile(latency, 0.95),
+        }
+    return summary
+
+
+def write_html_report(
+    quality_path: Path,
+    hindsight_ingest_path: Path,
+    tencent_seed_path: Path,
+    output: Path,
+) -> None:
+    quality = _read_json(quality_path)
+    hindsight_ingest = _read_json(hindsight_ingest_path)
+    tencent_seed = _read_json(tencent_seed_path)
+    summary = summarize_quality(quality)
+    by_category = _category_summary(quality)
+    comparison = _recall_comparison(quality)
+    tencent_layers = _tencent_layers(tencent_seed)
+    generated_at = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+
+    backend_rows = "".join(
+        _backend_row(backend, values) for backend, values in summary.items()
+    )
+    category_rows = "".join(
+        _category_row(category, values) for category, values in by_category.items()
+    )
+    failure_sections = "".join(
+        _failure_section(backend, quality) for backend in summary
+    )
+    source = quality.get("source", {})
+    judge_model = escape(str(quality.get("judge_model", "unknown")))
+    html = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Memory backend benchmark</title>
+<style>
+:root {{ color-scheme: light; --ink:#1d2329; --muted:#687078; --line:#d9dde1; --paper:#f7f8f8; --good:#087f5b; --warn:#b35c00; --bad:#b42318; --accent:#315c8c; }}
+* {{ box-sizing:border-box; }}
+body {{ margin:0; color:var(--ink); background:var(--paper); font:15px/1.5 Inter,system-ui,sans-serif; letter-spacing:0; }}
+header {{ background:#fff; border-bottom:1px solid var(--line); padding:32px max(24px,calc((100vw - 1180px)/2)); }}
+h1 {{ margin:0 0 8px; font-size:32px; letter-spacing:0; }}
+h2 {{ margin:0 0 14px; font-size:20px; letter-spacing:0; }}
+h3 {{ font-size:16px; letter-spacing:0; }}
+p {{ margin:6px 0; }}
+main {{ max-width:1180px; margin:0 auto; padding:28px 24px 56px; }}
+section {{ margin:0 0 34px; }}
+.meta {{ color:var(--muted); }}
+.metrics {{ display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:12px; margin-top:20px; }}
+.metric {{ background:#fff; border:1px solid var(--line); border-radius:6px; padding:14px; min-width:0; }}
+.metric strong {{ display:block; font-size:24px; }}
+.metric span {{ color:var(--muted); font-size:13px; }}
+.table-wrap {{ overflow:auto; border:1px solid var(--line); border-radius:6px; background:#fff; }}
+table {{ border-collapse:collapse; width:100%; min-width:880px; }}
+th,td {{ padding:11px 12px; border-bottom:1px solid var(--line); text-align:right; vertical-align:top; }}
+th:first-child,td:first-child {{ text-align:left; }}
+th {{ color:#4f5962; background:#f0f2f3; font-size:12px; text-transform:uppercase; }}
+tr:last-child td {{ border-bottom:0; }}
+.note {{ border-left:3px solid var(--accent); background:#fff; padding:12px 14px; }}
+.good {{ color:var(--good); }} .warn {{ color:var(--warn); }} .bad {{ color:var(--bad); }}
+details {{ background:#fff; border:1px solid var(--line); border-radius:6px; margin:8px 0; padding:10px 12px; }}
+summary {{ cursor:pointer; font-weight:650; }}
+.case {{ border-top:1px solid var(--line); padding:12px 0; }}
+.case:first-of-type {{ margin-top:10px; }}
+blockquote {{ margin:8px 0; padding:8px 12px; background:#f2f4f5; border-left:3px solid #89939c; white-space:pre-wrap; }}
+code {{ overflow-wrap:anywhere; }}
+@media(max-width:760px) {{ .metrics {{ grid-template-columns:repeat(2,minmax(0,1fr)); }} h1 {{ font-size:25px; }} main {{ padding-inline:14px; }} header {{ padding-inline:14px; }} }}
+</style>
+</head>
+<body>
+<header>
+  <h1>Hindsight vs TencentDB Agent Memory</h1>
+  <p class="meta">Coder Offtopic benchmark · {generated_at} · independent judge: {judge_model}</p>
+  <div class="metrics">
+    <div class="metric"><strong>{source.get('documents', 0)}</strong><span>source episodes</span></div>
+    <div class="metric"><strong>{source.get('events', 0)}</strong><span>source messages</span></div>
+    <div class="metric"><strong>{len(quality.get('recall', []))}</strong><span>source-grounded questions</span></div>
+    <div class="metric"><strong>{comparison['winner']}</strong><span>higher recall coverage</span></div>
+  </div>
+</header>
+<main>
+<section>
+  <h2>Executive comparison</h2>
+  <div class="table-wrap"><table>
+    <thead><tr><th>Backend</th><th>Recall /4</th><th>Success ≥3</th><th>Recall attribution /4</th><th>Contradiction</th><th>Faithfulness /4</th><th>Extraction attribution /4</th><th>Unsupported</th><th>P50</th><th>P95</th></tr></thead>
+    <tbody>{backend_rows}</tbody>
+  </table></div>
+  <p class="meta">Recall wins: Hindsight {comparison['hindsight_wins']}, Tencent {comparison['tencent_wins']}, ties {comparison['ties']}.</p>
+</section>
+<section>
+  <h2>Recall by question type</h2>
+  <div class="table-wrap"><table>
+    <thead><tr><th>Category</th><th>Cases</th><th>Hindsight /4</th><th>Tencent /4</th><th>Hindsight success</th><th>Tencent success</th></tr></thead>
+    <tbody>{category_rows}</tbody>
+  </table></div>
+</section>
+<section>
+  <h2>Extraction inventory</h2>
+  <div class="table-wrap"><table>
+    <thead><tr><th>Backend</th><th>Memories</th><th>Source-linked</th><th>Judged sample</th><th>Specificity /4</th><th>Usefulness /4</th><th>Over-combined</th><th>Types</th></tr></thead>
+    <tbody>{''.join(_inventory_row(k,v) for k,v in summary.items())}</tbody>
+  </table></div>
+  <p class="note"><strong>Tencent higher layers are reported separately:</strong> {tencent_layers['scene_blocks']} scene blocks and persona size {tencent_layers['persona_chars']} characters. They are not mixed into L1 fact scores because they do not preserve equivalent per-memory provenance.</p>
+</section>
+<section>
+  <h2>Ingestion throughput</h2>
+  <div class="table-wrap"><table>
+    <thead><tr><th>Backend</th><th>Input episodes</th><th>Wall time</th><th>Episodes / minute</th><th>Notes</th></tr></thead>
+    <tbody>
+      {_ingest_row('Hindsight', hindsight_ingest.get('documents', 0), hindsight_ingest.get('elapsed_seconds', 0), 'Synchronous retain, batch size 4')}
+      {_ingest_row('Tencent', _tencent_rounds(tencent_seed), tencent_seed.get('elapsed_seconds_client', 0), 'One round per source episode; L1 every 5 rounds')}
+    </tbody>
+  </table></div>
+</section>
+<section>
+  <h2>Lowest-scoring recall cases</h2>
+  {failure_sections}
+</section>
+<section>
+  <h2>Method and limits</h2>
+  <p>Both fresh stores received the same 376 exported Episode documents, preserving message text, timestamps, actor display names, canonical actor IDs, reply metadata, and source boundaries. Hindsight received one retain item per Episode. Tencent received one session with one conversation round per Episode so its configured five-round extraction window produced roughly one extraction call per five source documents.</p>
+  <p>The 60 Chinese questions were generated from raw source messages, not from either memory backend. Every evidence quote was programmatically verified as a verbatim substring of its cited message. The judge saw the reference answer, source evidence, and anonymized retrieved contexts.</p>
+  <p>Extraction quality uses a deterministic, type-balanced sample of source-linked memories. Unlinked memories affect provenance coverage but are not assigned an unsupported score without evidence. Results describe one Telegram group and one model/configuration snapshot; they are comparative evidence, not a universal ranking.</p>
+</section>
+</main>
+</body>
+</html>"""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(html, encoding="utf-8")
+
+
+def _category_summary(quality: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in quality.get("recall", []):
+        grouped[row["case"]["category"]].append(row)
+    result = {}
+    for category, rows in sorted(grouped.items()):
+        result[category] = {"cases": len(rows)}
+        for backend in ("hindsight", "tencent"):
+            scores = [row["grades"][backend]["answer_coverage"] for row in rows]
+            result[category][backend] = mean(scores)
+            result[category][f"{backend}_success"] = sum(score >= 3 for score in scores) / len(scores)
+    return result
+
+
+def _recall_comparison(quality: dict[str, Any]) -> dict[str, Any]:
+    hindsight_wins = tencent_wins = ties = 0
+    for row in quality.get("recall", []):
+        hindsight = row["grades"]["hindsight"]["answer_coverage"]
+        tencent = row["grades"]["tencent"]["answer_coverage"]
+        if hindsight > tencent:
+            hindsight_wins += 1
+        elif tencent > hindsight:
+            tencent_wins += 1
+        else:
+            ties += 1
+    winner = (
+        "Hindsight"
+        if hindsight_wins > tencent_wins
+        else "Tencent"
+        if tencent_wins > hindsight_wins
+        else "Tie"
+    )
+    return {
+        "hindsight_wins": hindsight_wins,
+        "tencent_wins": tencent_wins,
+        "ties": ties,
+        "winner": winner,
+    }
+
+
+def _backend_row(backend: str, values: dict[str, Any]) -> str:
+    return (
+        f"<tr><td><strong>{escape(backend.title())}</strong></td>"
+        f"<td>{_number(values['recall_coverage'])}</td>"
+        f"<td>{_percent(values['recall_success_rate'])}</td>"
+        f"<td>{_number(values['recall_attribution'])}</td>"
+        f"<td>{_percent(values['contradiction_rate'])}</td>"
+        f"<td>{_number(values['faithfulness'])}</td>"
+        f"<td>{_number(values['extraction_attribution'])}</td>"
+        f"<td>{_percent(values['unsupported_rate'])}</td>"
+        f"<td>{values['latency_p50_ms']:.0f} ms</td>"
+        f"<td>{values['latency_p95_ms']:.0f} ms</td></tr>"
+    )
+
+
+def _category_row(category: str, values: dict[str, Any]) -> str:
+    return (
+        f"<tr><td>{escape(category.replace('_', ' '))}</td><td>{values['cases']}</td>"
+        f"<td>{values['hindsight']:.2f}</td><td>{values['tencent']:.2f}</td>"
+        f"<td>{_percent(values['hindsight_success'])}</td>"
+        f"<td>{_percent(values['tencent_success'])}</td></tr>"
+    )
+
+
+def _inventory_row(backend: str, values: dict[str, Any]) -> str:
+    types = ", ".join(f"{escape(str(k))}: {v}" for k, v in values["types"].items())
+    return (
+        f"<tr><td><strong>{escape(backend.title())}</strong></td>"
+        f"<td>{values['memories']}</td><td>{_percent(values['source_link_rate'])}</td>"
+        f"<td>{values['extraction_sample']}</td><td>{_number(values['specificity'])}</td>"
+        f"<td>{_number(values['usefulness'])}</td><td>{_percent(values['overcombined_rate'])}</td>"
+        f"<td>{types}</td></tr>"
+    )
+
+
+def _ingest_row(name: str, documents: int, seconds: float, note: str) -> str:
+    rate = documents / seconds * 60 if seconds else 0
+    return (
+        f"<tr><td><strong>{escape(name)}</strong></td><td>{documents}</td>"
+        f"<td>{seconds / 60:.1f} min</td><td>{rate:.1f}</td><td>{escape(note)}</td></tr>"
+    )
+
+
+def _failure_section(backend: str, quality: dict[str, Any]) -> str:
+    rows = sorted(
+        quality.get("recall", []),
+        key=lambda row: (
+            row["grades"][backend]["answer_coverage"],
+            row["case"]["case_id"],
+        ),
+    )[:8]
+    cases = "".join(
+        "<div class=\"case\">"
+        f"<strong>{escape(row['case']['question'])}</strong>"
+        f"<p>Reference: {escape(row['case']['answer'])}</p>"
+        f"<p>Score: {row['grades'][backend]['answer_coverage']}/4 · "
+        f"{escape(row['grades'][backend]['reason'])}</p>"
+        f"<blockquote>{escape(row['measurements'][backend]['raw_context'][:2400])}</blockquote>"
+        "</div>"
+        for row in rows
+    )
+    return f"<details><summary>{escape(backend.title())}</summary>{cases}</details>"
+
+
+def _tencent_layers(seed: dict[str, Any]) -> dict[str, int]:
+    output_path = seed.get("outputPath") or seed.get("output_path")
+    if not isinstance(output_path, str):
+        return {"scene_blocks": 0, "persona_chars": 0}
+    root = Path(output_path)
+    persona = root / "persona.md"
+    return {
+        "scene_blocks": len(list((root / "scene_blocks").glob("*.md"))),
+        "persona_chars": len(persona.read_text(encoding="utf-8")) if persona.exists() else 0,
+    }
+
+
+def _tencent_rounds(seed: dict[str, Any]) -> int:
+    summary = seed.get("summary") or seed.get("seed") or {}
+    if isinstance(summary, dict):
+        for key in ("rounds", "conversations"):
+            value = summary.get(key)
+            if isinstance(value, int):
+                return value
+    output_path = seed.get("outputPath") or seed.get("output_path")
+    if isinstance(output_path, str):
+        manifest = Path(output_path) / ".metadata" / "manifest.json"
+        if manifest.exists():
+            value = _read_json(manifest).get("seed", {}).get("rounds")
+            if isinstance(value, int):
+                return value
+    return 0
+
+
+def _average(rows: list[dict[str, Any]], name: str) -> float:
+    values = [row[name] for row in rows if isinstance(row.get(name), (int, float))]
+    return mean(values) if values else 0.0
+
+
+def _boolean_rate(rows: list[dict[str, Any]], name: str) -> float:
+    return sum(bool(row.get(name)) for row in rows) / len(rows) if rows else 0.0
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = max(0, math.ceil(quantile * len(ordered)) - 1)
+    return float(ordered[index])
+
+
+def _number(value: float) -> str:
+    return f"{value:.2f}"
+
+
+def _percent(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return value

--- a/src/telefire/memory_benchmark/reporting.py
+++ b/src/telefire/memory_benchmark/reporting.py
@@ -155,7 +155,7 @@ code {{ overflow-wrap:anywhere; }}
   <div class="table-wrap"><table>
     <thead><tr><th>Backend</th><th>Input episodes</th><th>Wall time</th><th>Episodes / minute</th><th>Notes</th></tr></thead>
     <tbody>
-      {_ingest_row('Hindsight', hindsight_ingest.get('documents', 0), hindsight_ingest.get('elapsed_seconds', 0), f"Synchronous retain, batch size {hindsight_ingest.get('batch_size', 'unknown')}")}
+      {_ingest_row('Hindsight', hindsight_ingest.get('documents', 0), hindsight_ingest.get('elapsed_seconds', 0), f"Synchronous retain, batch size {hindsight_ingest.get('batch_size', 'unknown')}, concurrency {hindsight_ingest.get('concurrency', 'unknown')}")}
       {_ingest_row('Tencent', _tencent_rounds(tencent_seed), tencent_seed.get('elapsed_seconds_client', 0), 'One round per source episode; L1 every 5 rounds')}
     </tbody>
   </table></div>

--- a/src/telefire/memory_benchmark/reporting.py
+++ b/src/telefire/memory_benchmark/reporting.py
@@ -6,6 +6,7 @@ from html import escape
 import json
 import math
 from pathlib import Path
+import random
 from statistics import mean
 from typing import Any
 
@@ -143,6 +144,7 @@ code {{ overflow-wrap:anywhere; }}
     <tbody>{backend_rows}</tbody>
   </table></div>
   <p class="meta">Recall wins: Hindsight {comparison['hindsight_wins']}, Tencent {comparison['tencent_wins']}, ties {comparison['ties']}.</p>
+  <p class="note">Hindsight’s paired recall-coverage advantage is <strong>{comparison['coverage_difference']:.2f}/4</strong> (95% bootstrap interval {comparison['coverage_ci_low']:.2f} to {comparison['coverage_ci_high']:.2f}). Its success-rate advantage is <strong>{_percent(comparison['success_difference'])}</strong> (95% interval {_percent(comparison['success_ci_low'])} to {_percent(comparison['success_ci_high'])}).</p>
 </section>
 <section>
   <h2>Recall by question type</h2>
@@ -185,6 +187,9 @@ code {{ overflow-wrap:anywhere; }}
   <h2>Method and limits</h2>
   <p>Both fresh stores received the same 376 exported Episode documents, preserving message text, timestamps, actor display names, canonical actor IDs, reply metadata, and source boundaries. Hindsight received one retain item per Episode. Tencent received one session with one conversation round per Episode so its configured five-round extraction window produced roughly one extraction call per five source documents.</p>
   <p>The 60 Chinese questions were generated from raw source messages, not from either memory backend. Every evidence quote was programmatically verified as a verbatim substring of its cited message. The judge saw the reference answer, source evidence, and anonymized retrieved contexts.</p>
+  <p>A separate gpt-5.6-sol audit rejected 9 ambiguous or misattributed questions, leaving 51 scored cases. Confidence intervals use 20,000 deterministic paired bootstrap samples over those cases.</p>
+  <p>Tencent attempted all 376 rounds but recorded 363 L0 rows. The 13 dropped episodes are exactly the second episode in each of 13 same-millisecond timestamp pairs, exposing strict incremental-cursor behavior. Because 376 is not divisible by the configured five-round extraction window, the official seed runtime also spent two bounded five-minute waits on a one-round tail before its idle timer processed that tail. Both effects are included in measured throughput and are left unpatched.</p>
+  <p>Tencent seed does not formally await all L2/L3 completion before destroying its temporary pipeline. Eight scene blocks and a persona were present at completion and are reported as artifacts, but only provenance-linked L1 records are scored as extracted memories.</p>
   <p>Extraction quality uses a deterministic, type-balanced sample of source-linked memories. Unlinked memories affect provenance coverage but are not assigned an unsupported score without evidence. Results describe one Telegram group and one model/configuration snapshot; they are comparative evidence, not a universal ranking.</p>
 </section>
 </main>
@@ -210,9 +215,13 @@ def _category_summary(quality: dict[str, Any]) -> dict[str, dict[str, Any]]:
 
 def _recall_comparison(quality: dict[str, Any]) -> dict[str, Any]:
     hindsight_wins = tencent_wins = ties = 0
+    coverage_differences = []
+    success_differences = []
     for row in quality.get("recall", []):
         hindsight = row["grades"]["hindsight"]["answer_coverage"]
         tencent = row["grades"]["tencent"]["answer_coverage"]
+        coverage_differences.append(hindsight - tencent)
+        success_differences.append(int(hindsight >= 3) - int(tencent >= 3))
         if hindsight > tencent:
             hindsight_wins += 1
         elif tencent > hindsight:
@@ -226,11 +235,19 @@ def _recall_comparison(quality: dict[str, Any]) -> dict[str, Any]:
         if tencent_wins > hindsight_wins
         else "Tie"
     )
+    coverage_ci = _bootstrap_mean_interval(coverage_differences)
+    success_ci = _bootstrap_mean_interval(success_differences)
     return {
         "hindsight_wins": hindsight_wins,
         "tencent_wins": tencent_wins,
         "ties": ties,
         "winner": winner,
+        "coverage_difference": mean(coverage_differences) if coverage_differences else 0.0,
+        "coverage_ci_low": coverage_ci[0],
+        "coverage_ci_high": coverage_ci[1],
+        "success_difference": mean(success_differences) if success_differences else 0.0,
+        "success_ci_low": success_ci[0],
+        "success_ci_high": success_ci[1],
     }
 
 
@@ -309,7 +326,7 @@ def _failure_section(backend: str, quality: dict[str, Any]) -> str:
 
 
 def _tencent_layers(seed: dict[str, Any]) -> dict[str, int]:
-    output_path = seed.get("outputPath") or seed.get("output_path")
+    output_path = seed.get("outputDir") or seed.get("output_dir") or seed.get("output_path")
     if not isinstance(output_path, str):
         return {"scene_blocks": 0, "persona_chars": 0}
     root = Path(output_path)
@@ -321,13 +338,16 @@ def _tencent_layers(seed: dict[str, Any]) -> dict[str, int]:
 
 
 def _tencent_rounds(seed: dict[str, Any]) -> int:
+    rounds_processed = seed.get("rounds_processed")
+    if isinstance(rounds_processed, int):
+        return rounds_processed
     summary = seed.get("summary") or seed.get("seed") or {}
     if isinstance(summary, dict):
         for key in ("rounds", "conversations"):
             value = summary.get(key)
             if isinstance(value, int):
                 return value
-    output_path = seed.get("outputPath") or seed.get("output_path")
+    output_path = seed.get("outputDir") or seed.get("output_dir") or seed.get("output_path")
     if isinstance(output_path, str):
         manifest = Path(output_path) / ".metadata" / "manifest.json"
         if manifest.exists():
@@ -352,6 +372,20 @@ def _percentile(values: list[float], quantile: float) -> float:
     ordered = sorted(values)
     index = max(0, math.ceil(quantile * len(ordered)) - 1)
     return float(ordered[index])
+
+
+def _bootstrap_mean_interval(
+    values: list[float],
+    *,
+    samples: int = 20_000,
+) -> tuple[float, float]:
+    if not values:
+        return (0.0, 0.0)
+    generator = random.Random(20260715)
+    estimates = sorted(
+        mean(generator.choices(values, k=len(values))) for _ in range(samples)
+    )
+    return estimates[int(samples * 0.025)], estimates[int(samples * 0.975)]
 
 
 def _number(value: float) -> str:

--- a/src/telefire/memory_benchmark/reporting.py
+++ b/src/telefire/memory_benchmark/reporting.py
@@ -22,6 +22,13 @@ def summarize_quality(quality: dict[str, Any]) -> dict[str, dict[str, Any]]:
         ]
         recall_grades = [row["grades"][backend] for row in recall_rows]
         latency = [row["measurements"][backend]["elapsed_ms"] for row in recall_rows]
+        recalled_records = [
+            len(row["measurements"][backend].get("records", [])) for row in recall_rows
+        ]
+        context_characters = [
+            len(row["measurements"][backend].get("raw_context", ""))
+            for row in recall_rows
+        ]
         total = inventory.get("total", 0)
         summary[backend] = {
             "memories": total,
@@ -46,6 +53,8 @@ def summarize_quality(quality: dict[str, Any]) -> dict[str, dict[str, Any]]:
             "contradiction_rate": _boolean_rate(recall_grades, "contradiction"),
             "latency_p50_ms": _percentile(latency, 0.50),
             "latency_p95_ms": _percentile(latency, 0.95),
+            "average_recalled_records": mean(recalled_records) if recalled_records else 0.0,
+            "average_context_characters": mean(context_characters) if context_characters else 0.0,
         }
     return summary
 
@@ -151,6 +160,14 @@ code {{ overflow-wrap:anywhere; }}
   <p class="note"><strong>Tencent higher layers are reported separately:</strong> {tencent_layers['scene_blocks']} scene blocks and persona size {tencent_layers['persona_chars']} characters. They are not mixed into L1 fact scores because they do not preserve equivalent per-memory provenance.</p>
 </section>
 <section>
+  <h2>Retrieval footprint and latency</h2>
+  <div class="table-wrap"><table>
+    <thead><tr><th>Backend</th><th>Average recalled records</th><th>Average context characters</th><th>P50 latency</th><th>P95 latency</th></tr></thead>
+    <tbody>{''.join(_footprint_row(k,v) for k,v in summary.items())}</tbody>
+  </table></div>
+  <p class="meta">Context size is reported alongside recall quality because a backend returning more evidence has a larger opportunity to contain the answer.</p>
+</section>
+<section>
   <h2>Ingestion throughput</h2>
   <div class="table-wrap"><table>
     <thead><tr><th>Backend</th><th>Input episodes</th><th>Wall time</th><th>Episodes / minute</th><th>Notes</th></tr></thead>
@@ -249,6 +266,16 @@ def _inventory_row(backend: str, values: dict[str, Any]) -> str:
         f"<td>{values['extraction_sample']}</td><td>{_number(values['specificity'])}</td>"
         f"<td>{_number(values['usefulness'])}</td><td>{_percent(values['overcombined_rate'])}</td>"
         f"<td>{types}</td></tr>"
+    )
+
+
+def _footprint_row(backend: str, values: dict[str, Any]) -> str:
+    return (
+        f"<tr><td><strong>{escape(backend.title())}</strong></td>"
+        f"<td>{values['average_recalled_records']:.1f}</td>"
+        f"<td>{values['average_context_characters']:.0f}</td>"
+        f"<td>{values['latency_p50_ms']:.0f} ms</td>"
+        f"<td>{values['latency_p95_ms']:.0f} ms</td></tr>"
     )
 
 

--- a/src/telefire/memory_benchmark/source.py
+++ b/src/telefire/memory_benchmark/source.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import aiohttp
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodeEvent:
+    source_id: str
+    actor_id: str
+    actor_name: str
+    text: str
+    occurred_at: str
+    mentioned_at: str
+    reply_to_source_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SourceDocument:
+    document_id: str
+    content: str
+    context: str
+    timestamp: str
+    content_hash: str
+    events: tuple[EpisodeEvent, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCorpus:
+    bank_id: str
+    bank_name: str
+    exported_at: str
+    documents: tuple[SourceDocument, ...]
+
+    @property
+    def events(self) -> tuple[EpisodeEvent, ...]:
+        return tuple(event for document in self.documents for event in document.events)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": "telefire.memory-benchmark.source.v1",
+            "bank_id": self.bank_id,
+            "bank_name": self.bank_name,
+            "exported_at": self.exported_at,
+            "stats": {
+                "documents": len(self.documents),
+                "events": len(self.events),
+                "characters": sum(len(document.content) for document in self.documents),
+            },
+            "documents": [asdict(document) for document in self.documents],
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> SourceCorpus:
+        if value.get("schema") != "telefire.memory-benchmark.source.v1":
+            raise ValueError("Unsupported benchmark source schema")
+        documents = []
+        for supplied in value.get("documents", []):
+            events = tuple(EpisodeEvent(**event) for event in supplied.pop("events"))
+            documents.append(SourceDocument(events=events, **supplied))
+        return cls(
+            bank_id=value["bank_id"],
+            bank_name=value["bank_name"],
+            exported_at=value["exported_at"],
+            documents=tuple(documents),
+        )
+
+
+def parse_source_document(payload: dict[str, Any]) -> SourceDocument:
+    document_id = _required_string(payload, "id")
+    content = _required_string(payload, "original_text")
+    try:
+        episode = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Document {document_id} is not valid Episode JSON") from exc
+    if not isinstance(episode, dict) or episode.get("schema") != "telefire.memory.episode.v1":
+        raise ValueError(f"Document {document_id} has an unsupported Episode schema")
+    supplied_events = episode.get("events")
+    if not isinstance(supplied_events, list) or not supplied_events:
+        raise ValueError(f"Document {document_id} has no events")
+
+    events = []
+    for supplied in supplied_events:
+        if not isinstance(supplied, dict):
+            raise ValueError(f"Document {document_id} has a malformed event")
+        actor = supplied.get("actor")
+        if not isinstance(actor, dict):
+            raise ValueError(f"Document {document_id} has an event without an actor")
+        occurred_at = _iso_timestamp(supplied.get("occurred_at"))
+        mentioned_at = supplied.get("mentioned_at")
+        events.append(
+            EpisodeEvent(
+                source_id=_required_string(supplied, "source_id"),
+                actor_id=_required_string(actor, "id"),
+                actor_name=_required_string(actor, "display_name"),
+                text=_required_string(supplied, "text"),
+                occurred_at=occurred_at,
+                mentioned_at=(
+                    _iso_timestamp(mentioned_at)
+                    if mentioned_at is not None
+                    else occurred_at
+                ),
+                reply_to_source_id=_optional_string(supplied, "reply_to_source_id"),
+            )
+        )
+
+    retain = payload.get("retain_params") or {}
+    metadata = payload.get("document_metadata") or {}
+    timestamp = retain.get("event_date") or events[-1].occurred_at
+    context = retain.get("context") or "telegram conversation"
+    content_hash = metadata.get("content_hash") or hashlib.sha256(content.encode()).hexdigest()
+    if not all(isinstance(item, str) for item in (timestamp, context, content_hash)):
+        raise ValueError(f"Document {document_id} has malformed retain metadata")
+    return SourceDocument(
+        document_id=document_id,
+        content=content,
+        context=context,
+        timestamp=_iso_timestamp(timestamp),
+        content_hash=content_hash,
+        events=tuple(events),
+    )
+
+
+async def export_hindsight_bank(
+    base_url: str,
+    bank_id: str,
+    bank_name: str,
+    *,
+    concurrency: int = 8,
+) -> SourceCorpus:
+    timeout = aiohttp.ClientTimeout(total=120)
+    encoded_bank = quote(bank_id, safe="")
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        summaries: list[dict[str, Any]] = []
+        offset = 0
+        while True:
+            page = await _json_request(
+                session,
+                "GET",
+                f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}/documents",
+                params={"limit": "100", "offset": str(offset)},
+            )
+            items = page.get("items")
+            total = page.get("total")
+            if not isinstance(items, list) or not isinstance(total, int):
+                raise ValueError("Hindsight returned a malformed document page")
+            summaries.extend(items)
+            offset += len(items)
+            if offset >= total:
+                break
+            if not items:
+                raise ValueError("Hindsight document pagination stopped early")
+
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def detail(summary: dict[str, Any]) -> SourceDocument:
+            document_id = _required_string(summary, "id")
+            async with semaphore:
+                payload = await _json_request(
+                    session,
+                    "GET",
+                    f"{base_url.rstrip('/')}/v1/default/banks/{encoded_bank}/documents/"
+                    f"{quote(document_id, safe='')}",
+                )
+            return parse_source_document(payload)
+
+        documents = await asyncio.gather(*(detail(summary) for summary in summaries))
+
+    documents.sort(key=lambda document: (document.timestamp, document.document_id))
+    return SourceCorpus(
+        bank_id=bank_id,
+        bank_name=bank_name,
+        exported_at=datetime.now(UTC).isoformat(),
+        documents=tuple(documents),
+    )
+
+
+def write_corpus(corpus: SourceCorpus, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(corpus.to_dict(), ensure_ascii=False, separators=(",", ":")),
+        encoding="utf-8",
+    )
+
+
+def read_corpus(path: Path) -> SourceCorpus:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("Benchmark source must be a JSON object")
+    return SourceCorpus.from_dict(value)
+
+
+def tencent_seed_payload(corpus: SourceCorpus) -> dict[str, Any]:
+    sessions = []
+    for document in corpus.documents:
+        conversations = []
+        for event in document.events:
+            conversations.append(
+                [
+                    {
+                        "role": "user",
+                        "content": (
+                            f"[Telegram actor: {event.actor_name} | {event.actor_id}]\n"
+                            f"{event.text}"
+                        ),
+                        "timestamp": event.occurred_at,
+                    }
+                ]
+            )
+        sessions.append(
+            {
+                "sessionKey": corpus.bank_id,
+                "sessionId": document.document_id,
+                "conversations": conversations,
+            }
+        )
+    return {"sessions": sessions}
+
+
+async def _json_request(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    async with session.request(method, url, **kwargs) as response:
+        text = await response.text()
+        if response.status >= 400:
+            raise RuntimeError(f"{method} {url} failed with status {response.status}: {text[:500]}")
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{method} {url} returned invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"{method} {url} returned a non-object response")
+        return payload
+
+
+def _required_string(payload: dict[str, Any], name: str) -> str:
+    value = payload.get(name)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Missing or invalid {name}")
+    return value
+
+
+def _optional_string(payload: dict[str, Any], name: str) -> str | None:
+    value = payload.get(name)
+    if value is not None and not isinstance(value, str):
+        raise ValueError(f"Invalid {name}")
+    return value
+
+
+def _iso_timestamp(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError("Missing or invalid timestamp")
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"Invalid timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC).isoformat().replace("+00:00", "Z")

--- a/src/telefire/memory_benchmark/source.py
+++ b/src/telefire/memory_benchmark/source.py
@@ -64,8 +64,12 @@ class SourceCorpus:
             raise ValueError("Unsupported benchmark source schema")
         documents = []
         for supplied in value.get("documents", []):
-            events = tuple(EpisodeEvent(**event) for event in supplied.pop("events"))
-            documents.append(SourceDocument(events=events, **supplied))
+            document = dict(supplied)
+            supplied_events = document.pop("events", None)
+            if not isinstance(supplied_events, list):
+                raise ValueError("Benchmark source document has invalid events")
+            events = tuple(EpisodeEvent(**event) for event in supplied_events)
+            documents.append(SourceDocument(events=events, **document))
         return cls(
             bank_id=value["bank_id"],
             bank_name=value["bank_name"],

--- a/src/telefire/memory_benchmark/source.py
+++ b/src/telefire/memory_benchmark/source.py
@@ -199,30 +199,32 @@ def read_corpus(path: Path) -> SourceCorpus:
 
 
 def tencent_seed_payload(corpus: SourceCorpus) -> dict[str, Any]:
-    sessions = []
+    conversations = []
     for document in corpus.documents:
-        conversations = []
-        for event in document.events:
-            conversations.append(
-                [
-                    {
-                        "role": "user",
-                        "content": (
-                            f"[Telegram actor: {event.actor_name} | {event.actor_id}]\n"
-                            f"{event.text}"
-                        ),
-                        "timestamp": event.occurred_at,
-                    }
-                ]
-            )
-        sessions.append(
+        lines = [f"[Source document: {document.document_id}]"]
+        lines.extend(
+            f"[{event.occurred_at}] [Telegram actor: {event.actor_name} | "
+            f"{event.actor_id}] {event.text}"
+            for event in document.events
+        )
+        conversations.append(
+            [
+                {
+                    "role": "user",
+                    "content": "\n".join(lines),
+                    "timestamp": document.timestamp,
+                }
+            ]
+        )
+    return {
+        "sessions": [
             {
                 "sessionKey": corpus.bank_id,
-                "sessionId": document.document_id,
+                "sessionId": f"benchmark:{corpus.bank_id}",
                 "conversations": conversations,
             }
-        )
-    return {"sessions": sessions}
+        ]
+    }
 
 
 async def _json_request(

--- a/tests/test_memory_benchmark.py
+++ b/tests/test_memory_benchmark.py
@@ -14,6 +14,7 @@ from telefire.memory_benchmark.evaluation import (
     sample_memory_records,
     validate_recall_case,
 )
+from telefire.memory_benchmark.reporting import summarize_quality
 from telefire.memory_benchmark.source import (
     SourceCorpus,
     parse_source_document,
@@ -272,3 +273,68 @@ def test_json_parser_and_memory_sampling_are_deterministic():
         record.memory_id for record in second
     ]
     assert {record.memory_type for record in first} == {"world", "observation"}
+
+
+def test_quality_summary_keeps_recall_extraction_and_latency_separate():
+    quality = {
+        "inventories": {
+            "hindsight": {"total": 4, "source_linked": 4, "types": {"world": 4}},
+            "tencent": {"total": 2, "source_linked": 1, "types": {"episodic": 2}},
+        },
+        "extraction": {
+            "hindsight": {
+                "sample_size": 2,
+                "grades": [
+                    {
+                        "faithfulness": 4,
+                        "attribution": 4,
+                        "specificity": 3,
+                        "usefulness": 3,
+                        "temporal": None,
+                        "unsupported_claim": False,
+                        "overcombined": False,
+                    },
+                    {
+                        "faithfulness": 2,
+                        "attribution": 1,
+                        "specificity": 2,
+                        "usefulness": 2,
+                        "temporal": 3,
+                        "unsupported_claim": True,
+                        "overcombined": True,
+                    },
+                ],
+            },
+            "tencent": {"sample_size": 0, "grades": []},
+        },
+        "recall": [
+            {
+                "case": {"category": "direct"},
+                "measurements": {
+                    "hindsight": {"elapsed_ms": 100},
+                    "tencent": {"elapsed_ms": 20},
+                },
+                "grades": {
+                    "hindsight": {
+                        "answer_coverage": 4,
+                        "attribution": 4,
+                        "contradiction": False,
+                    },
+                    "tencent": {
+                        "answer_coverage": 2,
+                        "attribution": 3,
+                        "contradiction": True,
+                    },
+                },
+            }
+        ],
+    }
+
+    summary = summarize_quality(quality)
+
+    assert summary["hindsight"]["recall_success_rate"] == 1.0
+    assert summary["hindsight"]["faithfulness"] == 3.0
+    assert summary["hindsight"]["unsupported_rate"] == 0.5
+    assert summary["hindsight"]["latency_p50_ms"] == 100
+    assert summary["tencent"]["recall_success_rate"] == 0.0
+    assert summary["tencent"]["source_link_rate"] == 0.5

--- a/tests/test_memory_benchmark.py
+++ b/tests/test_memory_benchmark.py
@@ -5,8 +5,14 @@ import json
 import sqlite3
 
 from telefire.memory_benchmark.backends import (
+    MemoryRecord,
     parse_tencent_search,
     read_tencent_memories,
+)
+from telefire.memory_benchmark.evaluation import (
+    parse_json_object,
+    sample_memory_records,
+    validate_recall_case,
 )
 from telefire.memory_benchmark.source import (
     SourceCorpus,
@@ -113,9 +119,156 @@ def test_tencent_search_and_store_are_normalized_to_common_records(tmp_path):
             "2026-07-15T09:00:00Z",
         ),
     )
+    connection.execute(
+        """
+        CREATE TABLE l0_conversations (
+            record_id TEXT PRIMARY KEY, message_text TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        "INSERT INTO l0_conversations VALUES (?, ?)",
+        (
+            "source-message-1",
+            "[Source document: telegram:thread:1:11]\n"
+            "[2026-07-15T08:30:00Z] [Telegram actor: Alice | telegram:user:7] "
+            "下周二改为线上会议",
+        ),
+    )
     connection.commit()
     connection.close()
 
-    stored = read_tencent_memories(database)
-    assert stored[0].document_id == "telegram:thread:1:11"
+    records_directory = tmp_path / "records"
+    records_directory.mkdir()
+    (records_directory / "2026-07-15.jsonl").write_text(
+        json.dumps(
+            {
+                "id": "memory-1",
+                "content": "Alice 将发布时间改到了周二。",
+                "source_message_ids": ["source-message-1"],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    stored = read_tencent_memories(database, records_directory=records_directory)
+    assert stored[0].source_document_ids == ("telegram:thread:1:11",)
     assert stored[0].scene_name == "发布计划"
+
+
+def test_source_corpus_loading_does_not_mutate_payload():
+    payload = {
+        "schema": "telefire.memory-benchmark.source.v1",
+        "bank_id": "telegram:chat:1",
+        "bank_name": "Test Chat",
+        "exported_at": "2026-07-15T09:00:00+00:00",
+        "documents": [
+            {
+                "document_id": "telegram:thread:1:11",
+                "content": "{}",
+                "context": "test",
+                "timestamp": "2026-07-15T08:30:00Z",
+                "content_hash": "hash",
+                "events": [
+                    {
+                        "source_id": "telegram:message:1:11",
+                        "actor_id": "telegram:user:7",
+                        "actor_name": "Alice",
+                        "text": "下周二改为线上会议",
+                        "occurred_at": "2026-07-15T08:30:00Z",
+                        "mentioned_at": "2026-07-15T08:30:00Z",
+                        "reply_to_source_id": None,
+                    }
+                ],
+            }
+        ],
+    }
+
+    first = SourceCorpus.from_dict(payload)
+    second = SourceCorpus.from_dict(payload)
+
+    assert first == second
+    assert payload["documents"][0]["events"][0]["actor_name"] == "Alice"
+
+
+def test_recall_case_requires_verbatim_source_evidence():
+    document = parse_source_document(
+        {
+            "id": "telegram:thread:1:11",
+            "original_text": json.dumps(
+                {
+                    "schema": "telefire.memory.episode.v1",
+                    "events": [
+                        {
+                            "source_id": "telegram:message:1:11",
+                            "actor": {
+                                "id": "telegram:user:7",
+                                "display_name": "Alice",
+                            },
+                            "text": "下周二改为线上会议",
+                            "occurred_at": "2026-07-15T08:30:00Z",
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+            "retain_params": {},
+            "document_metadata": {},
+        }
+    )
+
+    valid = validate_recall_case(
+        {
+            "category": "temporal",
+            "question": "Alice 把会议改到了什么时候？",
+            "answer": "下周二。",
+            "evidence": [
+                {
+                    "document_id": "telegram:thread:1:11",
+                    "quote": "下周二改为线上会议",
+                }
+            ],
+        },
+        {document.document_id: document},
+    )
+    invalid = validate_recall_case(
+        {
+            "category": "temporal",
+            "question": "Alice 把会议改到了什么时候？",
+            "answer": "下周三。",
+            "evidence": [
+                {
+                    "document_id": "telegram:thread:1:11",
+                    "quote": "下周三改为线上会议",
+                }
+            ],
+        },
+        {document.document_id: document},
+    )
+
+    assert valid is not None
+    assert valid.evidence[0].quote == "下周二改为线上会议"
+    assert invalid is None
+
+
+def test_json_parser_and_memory_sampling_are_deterministic():
+    assert parse_json_object('```json\n{"score": 4}\n```') == {"score": 4}
+    records = tuple(
+        MemoryRecord(
+            backend="test",
+            memory_id=f"memory-{index}",
+            text=str(index),
+            memory_type="world" if index % 2 else "observation",
+        )
+        for index in range(10)
+    )
+
+    first = sample_memory_records(records, limit=5)
+    second = sample_memory_records(tuple(reversed(records)), limit=5)
+
+    assert [record.memory_id for record in first] == [
+        record.memory_id for record in second
+    ]
+    assert {record.memory_type for record in first} == {"world", "observation"}

--- a/tests/test_memory_benchmark.py
+++ b/tests/test_memory_benchmark.py
@@ -126,17 +126,17 @@ def test_tencent_search_and_store_are_normalized_to_common_records(tmp_path):
     connection.execute(
         """
         CREATE TABLE l0_conversations (
-            record_id TEXT PRIMARY KEY, message_text TEXT NOT NULL
+            record_id TEXT PRIMARY KEY, message_text TEXT NOT NULL,
+            timestamp INTEGER NOT NULL
         )
         """
     )
     connection.execute(
-        "INSERT INTO l0_conversations VALUES (?, ?)",
+        "INSERT INTO l0_conversations VALUES (?, ?, ?)",
         (
             "source-message-1",
-            "[Source document: telegram:thread:1:11]\n"
-            "[2026-07-15T08:30:00Z] [Telegram actor: Alice | telegram:user:7] "
-            "下周二改为线上会议",
+            "[Telegram actor: Alice | telegram:user:7] 下周二改为线上会议",
+            int(datetime(2026, 7, 15, 8, 30, tzinfo=UTC).timestamp() * 1_000),
         ),
     )
     connection.commit()
@@ -157,7 +157,41 @@ def test_tencent_search_and_store_are_normalized_to_common_records(tmp_path):
         encoding="utf-8",
     )
 
-    stored = read_tencent_memories(database, records_directory=records_directory)
+    source_document = parse_source_document(
+        {
+            "id": "telegram:thread:1:11",
+            "original_text": json.dumps(
+                {
+                    "schema": "telefire.memory.episode.v1",
+                    "events": [
+                        {
+                            "source_id": "telegram:message:1:11",
+                            "actor": {
+                                "id": "telegram:user:7",
+                                "display_name": "Alice",
+                            },
+                            "text": "下周二改为线上会议",
+                            "occurred_at": "2026-07-15T08:30:00Z",
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+            "retain_params": {"event_date": "2026-07-15T08:30:00Z"},
+            "document_metadata": {},
+        }
+    )
+    corpus = SourceCorpus(
+        bank_id="telegram:chat:1",
+        bank_name="Test Chat",
+        exported_at="2026-07-15T09:00:00Z",
+        documents=(source_document,),
+    )
+    stored = read_tencent_memories(
+        database,
+        records_directory=records_directory,
+        corpus=corpus,
+    )
     assert stored[0].source_document_ids == ("telegram:thread:1:11",)
     assert stored[0].scene_name == "发布计划"
 

--- a/tests/test_memory_benchmark.py
+++ b/tests/test_memory_benchmark.py
@@ -62,11 +62,15 @@ def test_episode_export_preserves_actor_time_and_source_boundaries():
     payload = tencent_seed_payload(corpus)
 
     session = payload["sessions"][0]
-    assert session["sessionId"] == document.document_id
+    assert session["sessionId"] == "benchmark:telegram:chat:1"
     message = session["conversations"][0][0]
     assert message == {
         "role": "user",
-        "content": "[Telegram actor: Alice | telegram:user:7]\n下周二改为线上会议",
+        "content": (
+            "[Source document: telegram:thread:1:11]\n"
+            "[2026-07-15T08:30:00Z] [Telegram actor: Alice | "
+            "telegram:user:7] 下周二改为线上会议"
+        ),
         "timestamp": "2026-07-15T08:30:00Z",
     }
 

--- a/tests/test_memory_benchmark.py
+++ b/tests/test_memory_benchmark.py
@@ -10,6 +10,9 @@ from telefire.memory_benchmark.backends import (
     read_tencent_memories,
 )
 from telefire.memory_benchmark.evaluation import (
+    RecallCase,
+    Evidence,
+    filter_validated_cases,
     parse_json_object,
     sample_memory_records,
     validate_recall_case,
@@ -338,3 +341,32 @@ def test_quality_summary_keeps_recall_extraction_and_latency_separate():
     assert summary["hindsight"]["latency_p50_ms"] == 100
     assert summary["tencent"]["recall_success_rate"] == 0.0
     assert summary["tencent"]["source_link_rate"] == 0.5
+
+
+def test_semantic_case_filter_requires_one_valid_review_per_case():
+    cases = (
+        RecallCase(
+            case_id="case-a",
+            category="direct",
+            question="Alice 改了什么？",
+            answer="会议时间。",
+            evidence=(Evidence(document_id="doc-1", quote="改会议时间"),),
+        ),
+        RecallCase(
+            case_id="case-b",
+            category="direct",
+            question="Bob 改了什么？",
+            answer="会议地点。",
+            evidence=(Evidence(document_id="doc-2", quote="改会议地点"),),
+        ),
+    )
+
+    accepted = filter_validated_cases(
+        cases,
+        [
+            {"case_id": "case-a", "valid": True, "reason": "supported"},
+            {"case_id": "case-b", "valid": False, "reason": "wrong actor"},
+        ],
+    )
+
+    assert accepted == (cases[0],)

--- a/tests/test_memory_benchmark.py
+++ b/tests/test_memory_benchmark.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 import json
+import sqlite3
 
+from telefire.memory_benchmark.backends import (
+    parse_tencent_search,
+    read_tencent_memories,
+)
 from telefire.memory_benchmark.source import (
     SourceCorpus,
     parse_source_document,
@@ -64,3 +69,49 @@ def test_episode_export_preserves_actor_time_and_source_boundaries():
         "content": "[Telegram actor: Alice | telegram:user:7]\n下周二改为线上会议",
         "timestamp": "2026-07-15T08:30:00Z",
     }
+
+
+def test_tencent_search_and_store_are_normalized_to_common_records(tmp_path):
+    results = parse_tencent_search(
+        """Found 1 matching memories:
+
+- **[episodic]** (priority: 75) [scene: 发布计划] (score: 0.032)
+  Alice 将发布时间改到了周二。
+"""
+    )
+
+    assert len(results) == 1
+    assert results[0].text == "Alice 将发布时间改到了周二。"
+    assert results[0].memory_type == "episodic"
+    assert results[0].scene_name == "发布计划"
+
+    database = tmp_path / "vectors.db"
+    connection = sqlite3.connect(database)
+    connection.execute(
+        """
+        CREATE TABLE l1_records (
+            record_id TEXT, content TEXT, type TEXT, scene_name TEXT,
+            session_id TEXT, timestamp_start TEXT, timestamp_end TEXT,
+            created_time TEXT
+        )
+        """
+    )
+    connection.execute(
+        "INSERT INTO l1_records VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "memory-1",
+            "Alice 将发布时间改到了周二。",
+            "episodic",
+            "发布计划",
+            "telegram:thread:1:11",
+            "2026-07-15T08:30:00Z",
+            "2026-07-15T08:30:00Z",
+            "2026-07-15T09:00:00Z",
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+    stored = read_tencent_memories(database)
+    assert stored[0].document_id == "telegram:thread:1:11"
+    assert stored[0].scene_name == "发布计划"

--- a/tests/test_memory_benchmark.py
+++ b/tests/test_memory_benchmark.py
@@ -314,8 +314,16 @@ def test_quality_summary_keeps_recall_extraction_and_latency_separate():
             {
                 "case": {"category": "direct"},
                 "measurements": {
-                    "hindsight": {"elapsed_ms": 100},
-                    "tencent": {"elapsed_ms": 20},
+                    "hindsight": {
+                        "elapsed_ms": 100,
+                        "raw_context": "four useful words",
+                        "records": [{}, {}],
+                    },
+                    "tencent": {
+                        "elapsed_ms": 20,
+                        "raw_context": "short",
+                        "records": [{}],
+                    },
                 },
                 "grades": {
                     "hindsight": {
@@ -339,6 +347,8 @@ def test_quality_summary_keeps_recall_extraction_and_latency_separate():
     assert summary["hindsight"]["faithfulness"] == 3.0
     assert summary["hindsight"]["unsupported_rate"] == 0.5
     assert summary["hindsight"]["latency_p50_ms"] == 100
+    assert summary["hindsight"]["average_recalled_records"] == 2
+    assert summary["hindsight"]["average_context_characters"] == 17
     assert summary["tencent"]["recall_success_rate"] == 0.0
     assert summary["tencent"]["source_link_rate"] == 0.5
 

--- a/tests/test_memory_benchmark.py
+++ b/tests/test_memory_benchmark.py
@@ -4,6 +4,8 @@ from datetime import UTC, datetime
 import json
 import sqlite3
 
+import pytest
+
 from telefire.memory_benchmark.backends import (
     MemoryRecord,
     parse_tencent_search,
@@ -13,11 +15,13 @@ from telefire.memory_benchmark.evaluation import (
     RecallCase,
     Evidence,
     filter_validated_cases,
+    grade_extraction_resilient,
+    grade_recall,
     parse_json_object,
     sample_memory_records,
     validate_recall_case,
 )
-from telefire.memory_benchmark.reporting import summarize_quality
+from telefire.memory_benchmark.reporting import _tencent_rounds, summarize_quality
 from telefire.memory_benchmark.source import (
     SourceCorpus,
     parse_source_document,
@@ -385,6 +389,7 @@ def test_quality_summary_keeps_recall_extraction_and_latency_separate():
     assert summary["hindsight"]["average_context_characters"] == 17
     assert summary["tencent"]["recall_success_rate"] == 0.0
     assert summary["tencent"]["source_link_rate"] == 0.5
+    assert _tencent_rounds({"rounds_processed": 376}) == 376
 
 
 def test_semantic_case_filter_requires_one_valid_review_per_case():
@@ -414,3 +419,74 @@ def test_semantic_case_filter_requires_one_valid_review_per_case():
     )
 
     assert accepted == (cases[0],)
+
+
+@pytest.mark.asyncio
+async def test_extraction_grading_splits_batches_when_judge_omits_an_item():
+    class IncompleteBatchJudge:
+        async def complete_json(self, **kwargs):
+            supplied = json.loads(kwargs["prompt"].split("\n\n", 1)[1])["items"]
+            selected = supplied[:1] if len(supplied) > 1 else supplied
+            return {
+                "grades": [
+                    {
+                        "memory_id": item["memory_id"],
+                        "faithfulness": 4,
+                        "attribution": 4,
+                        "specificity": 4,
+                        "usefulness": 4,
+                        "temporal": None,
+                        "unsupported_claim": False,
+                        "overcombined": False,
+                        "reason": "supported",
+                    }
+                    for item in selected
+                ]
+            }
+
+    grades = await grade_extraction_resilient(
+        IncompleteBatchJudge(),
+        [
+            {"memory_id": "memory-a", "extracted_memory": "A"},
+            {"memory_id": "memory-b", "extracted_memory": "B"},
+        ],
+    )
+
+    assert {grade["memory_id"] for grade in grades} == {"memory-a", "memory-b"}
+
+
+@pytest.mark.asyncio
+async def test_recall_grading_falls_back_to_one_backend_at_a_time():
+    class IncompleteComparisonJudge:
+        async def complete_json(self, **kwargs):
+            supplied = json.loads(kwargs["prompt"].split("\n\n", 1)[1])
+            labels = list(supplied["retrieved_contexts"])
+            selected = labels[:1]
+            return {
+                "grades": [
+                    {
+                        "label": label,
+                        "answer_coverage": 3,
+                        "attribution": 4,
+                        "temporal": None,
+                        "contradiction": False,
+                        "reason": "supported",
+                    }
+                    for label in selected
+                ]
+            }
+
+    case = RecallCase(
+        case_id="case-a",
+        category="direct",
+        question="谁改了会议？",
+        answer="Alice。",
+        evidence=(Evidence(document_id="doc-1", quote="Alice 改了会议"),),
+    )
+    grades = await grade_recall(
+        IncompleteComparisonJudge(),
+        case,
+        {"hindsight": "Alice 改了会议", "tencent": "Alice 改了会议"},
+    )
+
+    assert set(grades) == {"hindsight", "tencent"}

--- a/tests/test_memory_benchmark.py
+++ b/tests/test_memory_benchmark.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+
+from telefire.memory_benchmark.source import (
+    SourceCorpus,
+    parse_source_document,
+    tencent_seed_payload,
+)
+
+
+def test_episode_export_preserves_actor_time_and_source_boundaries():
+    content = json.dumps(
+        {
+            "schema": "telefire.memory.episode.v1",
+            "scope": {"id": "telegram:chat:1", "display_name": "Test Chat"},
+            "events": [
+                {
+                    "source_id": "telegram:message:1:11",
+                    "reply_to_source_id": "telegram:message:1:10",
+                    "actor": {
+                        "id": "telegram:user:7",
+                        "display_name": "Alice",
+                    },
+                    "text": "下周二改为线上会议",
+                    "occurred_at": "2026-07-15T08:30:00Z",
+                }
+            ],
+        },
+        ensure_ascii=False,
+    )
+    document = parse_source_document(
+        {
+            "id": "telegram:thread:1:11",
+            "original_text": content,
+            "retain_params": {
+                "context": "telegram conversation in Test Chat",
+                "event_date": "2026-07-15T08:30:00Z",
+            },
+            "document_metadata": {"content_hash": "content-hash"},
+        }
+    )
+
+    assert document.document_id == "telegram:thread:1:11"
+    assert document.events[0].actor_id == "telegram:user:7"
+    assert document.events[0].reply_to_source_id == "telegram:message:1:10"
+    assert document.events[0].mentioned_at == "2026-07-15T08:30:00Z"
+    assert document.timestamp == "2026-07-15T08:30:00Z"
+
+    corpus = SourceCorpus(
+        bank_id="telegram:chat:1",
+        bank_name="Test Chat",
+        exported_at=datetime.now(UTC).isoformat(),
+        documents=(document,),
+    )
+    payload = tencent_seed_payload(corpus)
+
+    session = payload["sessions"][0]
+    assert session["sessionId"] == document.document_id
+    message = session["conversations"][0][0]
+    assert message == {
+        "role": "user",
+        "content": "[Telegram actor: Alice | telegram:user:7]\n下周二改为线上会议",
+        "timestamp": "2026-07-15T08:30:00Z",
+    }


### PR DESCRIPTION
## Summary\n\n- add an isolated, reproducible benchmark harness for Hindsight and TencentDB Agent Memory\n- preserve equivalent source episode boundaries, actors, timestamps, and provenance across both backends\n- add source-grounded recall-case generation, independent validation, extraction/recall judging, checkpoint recovery, and a static HTML report\n- cover adapters, provenance recovery, scoring, summaries, and edge cases with unit tests\n\n## Verification\n\n- ........................................................................ [ 32%]
........................................................................ [ 64%]
....................................................sssss............... [ 97%]
......                                                                   [100%]
217 passed, 6 skipped in 3.78s: 217 passed, 6 skipped\n- \n- \n- report reviewed at desktop and mobile widths with no browser console errors\n\n## Result snapshot\n\nOn 376 Coder Offtopic episodes and 51 independently validated queries, Hindsight reached 82.4% recall success versus Tencent's 33.3%. Tencent had lower recall latency (p50 170 ms versus 316 ms) and slightly stronger extraction attribution, but materially weaker recall and more unsupported extracted claims in this configuration.\n\nPrivate source messages and generated benchmark results are intentionally excluded from git.