### PR TITLE
fix(memory): retain broadcast channel posts

### DIFF
--- a/src/telefire/ai.py
+++ b/src/telefire/ai.py
@@ -294,9 +294,14 @@ class ReplyTarget(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class MessageIdentity:
+    subject_id: str | None = None
     subject_display_name: str | None = None
     scope_display_name: str | None = None
     is_human: bool = True
+
+    @property
+    def is_memory_source(self) -> bool:
+        return self.is_human or self.subject_id is not None
 
 
 @dataclass(frozen=True, slots=True)
@@ -331,13 +336,27 @@ class TelegramMessageIdentityResolver:
             self._load_entity(message, "get_sender"),
             self._load_entity(message, "get_chat"),
         )
+        is_human = (
+            isinstance(sender, telegram_types.User)
+            and not bool(getattr(sender, "bot", False))
+        )
+        is_broadcast_channel_post = (
+            isinstance(sender, telegram_types.Channel)
+            and isinstance(chat, telegram_types.Channel)
+            and bool(getattr(chat, "broadcast", False))
+            and sender.id == chat.id
+        )
         return MessageIdentity(
+            subject_id=(
+                _telegram_subject_id(sender.id)
+                if is_human
+                else _telegram_channel_subject_id(sender.id)
+                if is_broadcast_channel_post
+                else None
+            ),
             subject_display_name=_telegram_display_name(sender),
             scope_display_name=_telegram_display_name(chat),
-            is_human=(
-                isinstance(sender, telegram_types.User)
-                and not bool(getattr(sender, "bot", False))
-            ),
+            is_human=is_human,
         )
 
     async def _load_entity(self, message: ReplyTarget, method_name: str) -> Any | None:
@@ -1169,7 +1188,7 @@ class PromptBuilder:
                 if (
                     message.sender_id is not None
                     and observation_text
-                    and message_identity.is_human
+                    and message_identity.is_memory_source
                 ):
                     observation = HumanObservation(
                         message_id=message.id,
@@ -1246,7 +1265,13 @@ class PromptBuilder:
                 f"context={','.join(membership)}",
             ]
             if message.sender_id is not None:
-                attributes.append(f"actor_id=telegram:user:{message.sender_id}")
+                attributes.append(
+                    "actor_id="
+                    + (
+                        message.identity.subject_id
+                        or _telegram_subject_id(message.sender_id)
+                    )
+                )
             if message.identity.subject_display_name:
                 attributes.append(
                     "actor_label="
@@ -2392,7 +2417,7 @@ class AIConversationHandler:
                         authored_prompt,
                         current_attachment,
                     )
-                    if current_observation and current_identity.is_human:
+                    if current_observation and current_identity.is_memory_source:
                         retained_observations.append(
                             HumanObservation(
                                 message_id=message.id,
@@ -2705,22 +2730,28 @@ class AIConversationHandler:
     ) -> AgentMemoryTarget | None:
         if self._memory is None:
             return None
-        participants: dict[int, str | None] = {
-            requester_id: requester_identity.subject_display_name
+        participants: dict[str, str | None] = {
+            _telegram_subject_id(requester_id): requester_identity.subject_display_name
         }
         for observation in observations:
+            subject_id = (
+                observation.identity.subject_id
+                or _telegram_subject_id(observation.sender_id)
+            )
             display_name = observation.identity.subject_display_name
-            if observation.sender_id not in participants or display_name:
-                participants[observation.sender_id] = display_name
+            if subject_id not in participants or display_name:
+                participants[subject_id] = display_name
             for mention in observation.mentioned_users:
-                if mention.user_id not in participants or mention.display_name:
-                    participants[mention.user_id] = mention.display_name
+                subject_id = _telegram_subject_id(mention.user_id)
+                if subject_id not in participants or mention.display_name:
+                    participants[subject_id] = mention.display_name
         for mention in current_mentions:
-            if mention.user_id not in participants or mention.display_name:
-                participants[mention.user_id] = mention.display_name
+            subject_id = _telegram_subject_id(mention.user_id)
+            if subject_id not in participants or mention.display_name:
+                participants[subject_id] = mention.display_name
         anchors = tuple(
             AgentIdentityAnchor(
-                identity=_telegram_subject_id(subject_id),
+                identity=subject_id,
                 label=display_name,
             )
             for subject_id, display_name in list(participants.items())[
@@ -3076,6 +3107,10 @@ def _telegram_subject_id(user_id: int) -> str:
     return f"telegram:user:{user_id}"
 
 
+def _telegram_channel_subject_id(channel_id: int) -> str:
+    return f"telegram:channel:{channel_id}"
+
+
 def _telegram_scope_id(chat_id: int) -> str:
     return f"telegram:chat:{chat_id}"
 
@@ -3123,7 +3158,10 @@ def _telegram_memory_episode(
                     chat_id,
                     observation.message_id,
                 ),
-                actor_id=_telegram_subject_id(observation.sender_id),
+                actor_id=(
+                    observation.identity.subject_id
+                    or _telegram_subject_id(observation.sender_id)
+                ),
                 actor_display_name=observation.identity.subject_display_name,
                 occurred_at=observation.occurred_at,
                 text=observation.text,

--- a/src/telefire/ai_dream.py
+++ b/src/telefire/ai_dream.py
@@ -1007,7 +1007,7 @@ class TelegramDreamScanner:
                 if not observation_text:
                     return None
                 identity = await identity_for(message)
-                if not identity.is_human:
+                if not identity.is_memory_source:
                     return None
                 mentioned_users = (
                     await self._prompt_builder.resolve_mentions(message)

--- a/tests/test_ai_dream.py
+++ b/tests/test_ai_dream.py
@@ -186,6 +186,16 @@ class CountingIdentityResolver(FakeIdentityResolver):
         return await super().resolve(message)
 
 
+class BroadcastChannelIdentityResolver:
+    async def resolve(self, message):
+        return MessageIdentity(
+            subject_id="telegram:channel:2064685671",
+            subject_display_name="Seele Leaks",
+            scope_display_name="Seele Leaks",
+            is_human=False,
+        )
+
+
 class FakeAttachmentDescriber:
     async def describe(self, message):
         if message.file is None:
@@ -207,6 +217,7 @@ async def make_scanner(
     max_messages=100,
     lease_seconds=3_600,
     clock=lambda: NOW.timestamp(),
+    identity_resolver=None,
 ):
     store = await AIStateRepository(tmp_path / "ai.db").connect()
     await store.set_memory_enabled("telegram:chat:-1001", True, "Dream Group")
@@ -215,7 +226,7 @@ async def make_scanner(
         store=store,
         memory=memory,
         prompt_builder=PromptBuilder(
-            identity_resolver=FakeIdentityResolver(),
+            identity_resolver=identity_resolver or FakeIdentityResolver(),
             attachment_describer=attachment_describer,
         ),
         settings=DreamSettings(
@@ -1109,6 +1120,32 @@ async def test_dream_excludes_marked_messages_bots_and_keeps_attachment_text(tmp
         assert result.documents_created == 1
         assert memory.retain_calls[0]["episode"].events[0].text == (
             "Attachment description: launch-plan whiteboard sketch."
+        )
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_dream_retains_broadcast_channel_posts_with_channel_actor(tmp_path):
+    post = FakeMessage(
+        43,
+        "Version 3.4 preview notes",
+        sender_id=-1002064685671,
+    )
+    source = FakeSource([post])
+    memory = FakeMemory()
+    store, scanner = await make_scanner(
+        tmp_path,
+        source,
+        memory,
+        identity_resolver=BroadcastChannelIdentityResolver(),
+    )
+    try:
+        result = await scanner.run_scope(-1001)
+
+        assert result.messages_retained == 1
+        assert memory.retain_calls[0]["episode"].events[0].actor_id == (
+            "telegram:channel:2064685671"
         )
     finally:
         await store.close()

--- a/tests/test_ai_memory_integration.py
+++ b/tests/test_ai_memory_integration.py
@@ -366,6 +366,26 @@ class FakeTelegramIdentityMessage:
         )
 
 
+class FakeBroadcastChannelMessage:
+    async def get_sender(self):
+        return telegram_types.Channel(
+            id=2064685671,
+            title="Seele Leaks",
+            photo=telegram_types.ChatPhotoEmpty(),
+            date=None,
+            broadcast=True,
+        )
+
+    async def get_chat(self):
+        return telegram_types.Channel(
+            id=2064685671,
+            title="Seele Leaks",
+            photo=telegram_types.ChatPhotoEmpty(),
+            date=None,
+            broadcast=True,
+        )
+
+
 class FakeMentionClient:
     def __init__(self):
         self.entities = {
@@ -425,10 +445,26 @@ async def test_telegram_identity_resolver_uses_entity_display_names():
         FakeTelegramIdentityMessage()
     )
     assert identity == MessageIdentity(
+        subject_id="telegram:user:20",
         subject_display_name="Alice Example",
         scope_display_name="Engineering Group",
         is_human=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_telegram_identity_resolver_accepts_broadcast_channel_posts():
+    identity = await TelegramMessageIdentityResolver().resolve(
+        FakeBroadcastChannelMessage()
+    )
+
+    assert identity == MessageIdentity(
+        subject_id="telegram:channel:2064685671",
+        subject_display_name="Seele Leaks",
+        scope_display_name="Seele Leaks",
+        is_human=False,
+    )
+    assert identity.is_memory_source
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- assign canonical Telegram channel actor IDs to a broadcast channel's own posts
- allow those posts through automatic and explicit memory ingestion
- preserve bot/unresolved sender exclusion and human-only revision behavior

## Verification
- `uv run pytest -q` (219 passed, 6 skipped)
- `uv run ruff check src/telefire/ai.py src/telefire/ai_dream.py tests/test_ai_dream.py tests/test_ai_memory_integration.py`
- sampled `@Seele_Leaks` and confirmed its posts resolve to the broadcast channel entity
