### PR TITLE
Throttle continuous memory polling

### DIFF
--- a/src/telefire/ai_dream.py
+++ b/src/telefire/ai_dream.py
@@ -822,7 +822,7 @@ class TelegramDreamScanner:
             documents_created=documents_created,
             documents_unchanged=documents_unchanged,
         )
-        if self._logger is not None:
+        if self._logger is not None and result.messages_seen:
             finished_at = self._monotonic()
             self._logger.info(
                 "Dream retention complete "
@@ -1439,7 +1439,6 @@ class ContinuousMemoryScheduler:
         self._settings = settings
         self._sleep = sleep
         self._logger = logger
-        self._wake = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
 
     def start(self) -> None:
@@ -1449,9 +1448,6 @@ class ContinuousMemoryScheduler:
             self._run_forever(),
             name="telefire-continuous-memory-scheduler",
         )
-
-    def notify(self) -> None:
-        self._wake.set()
 
     async def close(self) -> None:
         if self._task is None:
@@ -1526,7 +1522,12 @@ class ContinuousMemoryScheduler:
             messages_seen=messages_seen,
             messages_retained=messages_retained,
         )
-        if self._logger is not None:
+        if self._logger is not None and (
+            schedule_result.messages_seen
+            or schedule_result.scopes_failed
+            or schedule_result.scopes_busy
+            or schedule_result.scopes_pending
+        ):
             self._logger.info(
                 "Continuous memory cycle complete "
                 "(scopes=%s, succeeded=%s, failed=%s, busy=%s, pending=%s, "
@@ -1543,7 +1544,6 @@ class ContinuousMemoryScheduler:
 
     async def _run_forever(self) -> None:
         while True:
-            self._wake.clear()
             try:
                 result = await self.run_once()
             except Exception as exc:
@@ -1556,11 +1556,5 @@ class ContinuousMemoryScheduler:
                 result = None
             if result is not None and result.scopes_pending:
                 await self._sleep(0)
-                continue
-            try:
-                await asyncio.wait_for(
-                    self._wake.wait(),
-                    timeout=self._settings.poll_interval_seconds,
-                )
-            except TimeoutError:
-                pass
+            else:
+                await self._sleep(self._settings.poll_interval_seconds)

--- a/src/telefire/plugins/ai.py
+++ b/src/telefire/plugins/ai.py
@@ -282,13 +282,6 @@ class TelegramAI(TelegramCommand, metaclass=PluginMount):
 
     async def _on_message(self, event) -> None:
         if self._handler is not None:
-            continuous_scheduler = getattr(
-                self,
-                "_continuous_memory_scheduler",
-                None,
-            )
-            if continuous_scheduler is not None:
-                continuous_scheduler.notify()
             try:
                 if await self._handle_saved_memory(event.message):
                     return
@@ -299,9 +292,6 @@ class TelegramAI(TelegramCommand, metaclass=PluginMount):
                     event.message.chat_id,
                     event.message.id,
                 )
-            finally:
-                if continuous_scheduler is not None:
-                    continuous_scheduler.notify()
 
     async def _handle_saved_memory(self, message) -> bool:
         if not self._is_saved_messages_message(message):

--- a/tests/test_ai_dream.py
+++ b/tests/test_ai_dream.py
@@ -2064,6 +2064,39 @@ async def test_continuous_scheduler_immediately_drains_backlog(tmp_path):
         await store.close()
 
 
+@pytest.mark.asyncio
+async def test_continuous_scheduler_waits_between_idle_cycles(tmp_path):
+    class RecordingSleep:
+        def __init__(self):
+            self.calls = []
+            self.started = asyncio.Event()
+
+        async def __call__(self, seconds):
+            self.calls.append(seconds)
+            self.started.set()
+            await asyncio.Event().wait()
+
+    store = await AIStateRepository(tmp_path / "ai.db").connect()
+    sleep = RecordingSleep()
+    scheduler = ContinuousMemoryScheduler(
+        scanner=FakeContinuousScanner(),
+        store=store,
+        settings=ContinuousMemorySchedulerSettings(
+            poll_interval_seconds=10,
+            concurrency=1,
+            scope_batch_size=1,
+        ),
+        sleep=sleep,
+    )
+    try:
+        scheduler.start()
+        await asyncio.wait_for(sleep.started.wait(), timeout=1)
+        assert sleep.calls == [10]
+    finally:
+        await scheduler.close()
+        await store.close()
+
+
 def test_dream_settings_load_temporal_session_limits(monkeypatch):
     monkeypatch.setenv("TELEFIRE_MEMORY_DREAM_SESSION_IDLE_SECONDS", "120")
     monkeypatch.setenv("TELEFIRE_MEMORY_DREAM_SESSION_MAX_SPAN_SECONDS", "600")

--- a/tests/test_ai_plugin.py
+++ b/tests/test_ai_plugin.py
@@ -58,27 +58,6 @@ class BlockingRecordingHandler(RecordingHandler):
         return True
 
 
-class BlockingMessageHandler(RecordingHandler):
-    def __init__(self):
-        super().__init__()
-        self.started = asyncio.Event()
-        self.release = asyncio.Event()
-
-    async def handle(self, message):
-        self.messages.append(message)
-        self.started.set()
-        await self.release.wait()
-        return True
-
-
-class RecordingContinuousScheduler:
-    def __init__(self):
-        self.notifications = 0
-
-    def notify(self):
-        self.notifications += 1
-
-
 class FakeStateRepository:
     def __init__(self):
         self.processed = set()
@@ -211,27 +190,6 @@ def make_plugin(*, handler, store, client, owner_id=10, edit_limiter=None):
     plugin.service = SimpleNamespace(client=client)
     plugin.logger = RecordingLogger()
     return plugin
-
-
-@pytest.mark.asyncio
-async def test_message_event_wakes_continuous_ingestion_before_and_after_handling():
-    handler = BlockingMessageHandler()
-    scheduler = RecordingContinuousScheduler()
-    message = FakeSavedMessage(forwarded=False, text="ordinary message")
-    plugin = make_plugin(
-        handler=handler,
-        store=FakeStateRepository(),
-        client=FakeTelegramClient(None),
-    )
-    plugin._continuous_memory_scheduler = scheduler
-
-    task = asyncio.create_task(plugin._on_message(SimpleNamespace(message=message)))
-    await handler.started.wait()
-    assert scheduler.notifications == 1
-
-    handler.release.set()
-    await task
-    assert scheduler.notifications == 2
 
 
 def assert_saved_memory_status(message, final_text):


### PR DESCRIPTION
## Summary
- remove global Telegram-event wakeups from continuous memory ingestion
- poll at the configured interval while caught up and loop immediately only when a scope reports a real backlog
- suppress empty scanner and scheduler cycle logs

## Reason
The deployed worker was awakened by traffic from every Telegram chat on the account, causing repeated empty scans for the one continuous scope.

## Verification
- `uv run pytest -q` (`234 passed, 6 skipped`)
- Ruff passes on all touched files
- `git diff --check`
