### PR TITLE
Add remote memory scope controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,15 +338,22 @@ Commands and reply behavior:
 - Every successful `/ai` request retains its bounded human reply path plus the
   current prompt. No chat-level memory switch is required. `/ai_memory_enable`
   instead enables continuous capture of all eligible settled messages arriving
-  after the command; `/ai_memory_disable` stops that background capture.
+  after the command; `/ai_memory_disable` stops that background capture. Both
+  commands accept an optional numeric Telegram group/channel ID, for example
+  `/ai_memory_enable -1002064685671`, so the owner can manage another accessible
+  chat from anywhere. Remote enable starts after that target's latest message.
 - `/ai_dream_enable` separately enables scheduled Dream scans and
-  `/ai_dream_disable` disables them. Continuous capture overrides Dream while both
-  settings are enabled, so the same chat is never scanned by both workers.
+  `/ai_dream_disable` disables them. These commands accept the same optional
+  numeric group/channel ID. Continuous capture overrides Dream while both settings
+  are enabled, so the same chat is never scanned by both workers.
   `/ai_memory_dream` runs one bounded Dream scan immediately when Dream is enabled
   and continuous capture is disabled. `/ai_memory_status` reports both modes,
-  their cursor, and the latest Dream attempt, success, and failure. Recall and
-  one-shot `/ai_memory` do not depend on either mode. Accepted owner
-  memory-management commands delete on the configured timer.
+  their cursor, and the latest Dream attempt, success, and failure for the current
+  chat. `/ai_memory_list` reports every chat with continuous memory or Dream
+  enabled, including its display name, canonical numeric ID, cursor, override
+  state, and latest errors. Recall and one-shot `/ai_memory` do not depend on
+  either mode. Accepted owner memory-management commands delete on the configured
+  timer.
 - Dream-enabled chats are scanned on `TELEFIRE_MEMORY_DREAM_CRON` (hourly by default).
   Lookback, overlap, settlement delay, concurrency, transport batch size, and
   bounded retry settings use the `TELEFIRE_MEMORY_DREAM_*` variables documented

--- a/src/telefire/ai.py
+++ b/src/telefire/ai.py
@@ -310,12 +310,28 @@ class MentionedUser:
     display_name: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class MemoryScopeTarget:
+    chat_id: int
+    display_name: str | None = None
+    latest_message_id: int = 0
+
+
 class MessageIdentityResolver(Protocol):
     async def resolve(self, message: ReplyTarget) -> MessageIdentity: ...
 
 
 class MessageMentionResolver(Protocol):
     async def resolve(self, message: ReplyTarget) -> tuple[MentionedUser, ...]: ...
+
+
+class MemoryScopeTargetResolver(Protocol):
+    async def resolve(
+        self,
+        chat_id: int,
+        *,
+        include_latest_message: bool = False,
+    ) -> MemoryScopeTarget: ...
 
 
 class MessageHistorySource(Protocol):
@@ -417,6 +433,48 @@ class TelegramMessageMentionResolver:
         return tuple(resolved.values())
 
 
+class TelegramMemoryScopeTargetResolver:
+    def __init__(self, client: Any, *, logger: Any | None = None):
+        self._client = client
+        self._logger = logger
+
+    async def resolve(
+        self,
+        chat_id: int,
+        *,
+        include_latest_message: bool = False,
+    ) -> MemoryScopeTarget:
+        try:
+            entity = await self._client.get_entity(chat_id)
+            if not isinstance(
+                entity,
+                (telegram_types.Chat, telegram_types.Channel),
+            ):
+                raise ValueError("Telegram target is not a group or channel")
+            latest_message_id = 0
+            if include_latest_message:
+                messages = await self._client.get_messages(entity, limit=1)
+                if messages:
+                    latest_message_id = int(messages[0].id)
+        except Exception as exc:
+            if self._logger is not None:
+                self._logger.warning(
+                    "Telegram memory scope lookup failed "
+                    "(chat_id=%s, error=%s): %s",
+                    chat_id,
+                    type(exc).__name__,
+                    exc,
+                )
+            raise ValueError(
+                "Telegram group or channel is inaccessible"
+            ) from exc
+        return MemoryScopeTarget(
+            chat_id=telegram_utils.get_peer_id(entity),
+            display_name=_telegram_display_name(entity),
+            latest_message_id=latest_message_id,
+        )
+
+
 class ConversationStore(Protocol):
     async def get_answer(
         self, chat_id: int, answer_message_id: int
@@ -470,6 +528,10 @@ class ConversationStore(Protocol):
         scope_id: str,
     ) -> MemoryScopeState: ...
 
+    async def list_enabled_memory_scope_states(
+        self,
+    ) -> tuple[MemoryScopeState, ...]: ...
+
     async def set_continuous_memory_enabled(
         self,
         scope_id: str,
@@ -514,12 +576,14 @@ class MemoryDreamState:
 @dataclass(frozen=True, slots=True)
 class MemoryScopeState:
     scope_id: str
+    display_name: str | None = None
     continuous_enabled: bool = False
     dream_enabled: bool = False
     continuous_cursor_message_id: int | None = None
     continuous_last_attempt_at: float | None = None
     continuous_last_success_at: float | None = None
     continuous_last_error: str | None = None
+    dream_last_error: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -814,6 +878,23 @@ def parse_memory_backfill(text: str | None) -> MemoryBackfillRequest | None:
         return MemoryBackfillRequest(mode=mode, value=value)
     except ValueError:
         return None
+
+
+def _parse_optional_memory_scope_target(
+    text: str,
+    command: str,
+) -> tuple[bool, int | None]:
+    parts = text.split()
+    if parts == [command]:
+        return True, None
+    if len(parts) != 2 or parts[0] != command:
+        return False, None
+    candidate = parts[1]
+    digits = candidate.removeprefix("-")
+    if not digits or not digits.isascii() or not digits.isdecimal():
+        return False, None
+    chat_id = int(candidate)
+    return (True, chat_id) if chat_id != 0 else (False, None)
 
 
 def _memory_message_text(text: str) -> str:
@@ -1866,12 +1947,45 @@ class AIStateRepository:
             return MemoryScopeState(scope_id=scope_id)
         return MemoryScopeState(
             scope_id=scope_id,
+            display_name=row["display_name"],
             continuous_enabled=bool(row["continuous_enabled"]),
             dream_enabled=bool(row["dream_enabled"]),
             continuous_cursor_message_id=row["continuous_cursor_message_id"],
             continuous_last_attempt_at=row["continuous_last_attempt_at"],
             continuous_last_success_at=row["continuous_last_success_at"],
             continuous_last_error=row["continuous_last_error"],
+        )
+
+    async def list_enabled_memory_scope_states(
+        self,
+    ) -> tuple[MemoryScopeState, ...]:
+        connection = self._require_connection()
+        cursor = await connection.execute(
+            """
+            SELECT
+                scope.*,
+                COALESCE(
+                    NULLIF(scope.display_name, ''),
+                    labels.display_name
+                ) AS resolved_display_name,
+                dream.last_error AS dream_last_error
+            FROM ai_memory_scopes AS scope
+            LEFT JOIN ai_memory_scope_labels AS labels
+                ON labels.scope_id = scope.scope_id
+            LEFT JOIN ai_memory_dream_state AS dream
+                ON dream.scope_id = scope.scope_id
+            WHERE scope.continuous_enabled = 1 OR scope.dream_enabled = 1
+            ORDER BY
+                COALESCE(
+                    NULLIF(scope.display_name, ''),
+                    labels.display_name,
+                    scope.scope_id
+                ) COLLATE NOCASE,
+                scope.scope_id
+            """
+        )
+        return tuple(
+            [_memory_scope_state_from_row(row) async for row in cursor]
         )
 
     async def record_memory_labels(
@@ -2350,6 +2464,7 @@ class AIConversationHandler:
         rate_limiter: AIRateLimiter | None = None,
         memory: MemoryClient | None = None,
         dream_runner: MemoryDreamRunner | None = None,
+        memory_scope_resolver: MemoryScopeTargetResolver | None = None,
         memory_command_delete_delay: float = 3.0,
         logger: Any | None = None,
     ):
@@ -2362,6 +2477,7 @@ class AIConversationHandler:
         self._rate_limiter = rate_limiter or AIRateLimiter(store)
         self._memory = memory
         self._dream_runner = dream_runner
+        self._memory_scope_resolver = memory_scope_resolver
         self._memory_command_delete_delay = memory_command_delete_delay
         self._memory_command_delete_tasks: set[asyncio.Task[None]] = set()
         self._logger = logger
@@ -2396,21 +2512,42 @@ class AIConversationHandler:
                 )
                 return True
             return await self._handle_memory_backfill(message, request)
-        if command in {
+        if command_name in {
             "/ai_memory_enable",
             "/ai_memory_disable",
-            "/ai_memory_status",
-            "/ai_memory_dream",
             "/ai_dream_enable",
             "/ai_dream_disable",
         }:
             if not is_owner_control:
                 return False
+            valid_target, target_chat_id = _parse_optional_memory_scope_target(
+                command,
+                command_name,
+            )
+            if not valid_target:
+                await self._reply_memory_excluded(
+                    message,
+                    f"Usage: {command_name} [numeric group/channel ID]",
+                    kind="memory-control",
+                )
+                return True
+            return await self._handle_memory_scope_command(
+                message,
+                command_name,
+                target_chat_id=target_chat_id,
+            )
+        if command in {
+            "/ai_memory_status",
+            "/ai_memory_list",
+            "/ai_memory_dream",
+        }:
+            if not is_owner_control:
+                return False
             if command == "/ai_memory_dream":
-                handled = await self._handle_memory_dream(message)
-            else:
-                handled = await self._handle_memory_scope_command(message, command)
-            return handled
+                return await self._handle_memory_dream(message)
+            if command == "/ai_memory_list":
+                return await self._handle_memory_scope_list(message)
+            return await self._handle_memory_scope_command(message, command)
         if command in {"/ai_allow", "/ai_deny"}:
             if not is_owner_control:
                 return False
@@ -2720,10 +2857,12 @@ class AIConversationHandler:
         self,
         message: ReplyTarget,
         command: str,
+        *,
+        target_chat_id: int | None = None,
     ) -> bool:
         assert message.chat_id is not None
-        scope_id = _telegram_scope_id(message.chat_id)
         if command == "/ai_memory_status":
+            scope_id = _telegram_scope_id(message.chat_id)
             scope = await self._store.get_memory_scope_state(scope_id)
             state = await self._store.get_memory_dream_state(scope_id)
             dream_status = "enabled" if scope.dream_enabled else "disabled"
@@ -2751,45 +2890,112 @@ class AIConversationHandler:
                     f"Last Dream error: {state.last_error or 'none'}",
                 )
             )
-        elif command in {"/ai_memory_enable", "/ai_memory_disable"}:
-            enabled = command == "/ai_memory_enable"
+            await self._schedule_memory_command_delete(message, command)
+            await self._reply_memory_excluded(
+                message,
+                response,
+                kind="memory-control",
+            )
+            return True
+
+        is_remote = target_chat_id is not None
+        if is_remote:
+            if self._memory_scope_resolver is None:
+                await self._reply_memory_excluded(
+                    message,
+                    "Remote Telegram group/channel lookup is unavailable.",
+                    kind="memory-control",
+                )
+                return True
+            try:
+                target = await self._memory_scope_resolver.resolve(
+                    target_chat_id,
+                    include_latest_message=command == "/ai_memory_enable",
+                )
+            except Exception as exc:
+                self._log_memory_failure("scope lookup", exc)
+                await self._reply_memory_excluded(
+                    message,
+                    "Unable to access that Telegram group/channel. "
+                    "Check the numeric chat ID and this account's access.",
+                    kind="memory-control",
+                )
+                return True
+        else:
             identity = await self._prompt_builder.resolve_identity(message)
+            target = MemoryScopeTarget(
+                chat_id=message.chat_id,
+                display_name=identity.scope_display_name,
+                latest_message_id=message.id,
+            )
+
+        scope_id = _telegram_scope_id(target.chat_id)
+        target_label = _memory_scope_target_label(target)
+        destination = target_label if is_remote else "this chat"
+        if command in {"/ai_memory_enable", "/ai_memory_disable"}:
+            enabled = command == "/ai_memory_enable"
             await self._store.set_continuous_memory_enabled(
                 scope_id,
                 enabled,
-                identity.scope_display_name,
-                cursor_message_id=message.id if enabled else None,
+                target.display_name,
+                cursor_message_id=target.latest_message_id if enabled else None,
             )
             scope = await self._store.get_memory_scope_state(scope_id)
             if enabled:
                 response = (
-                    "Continuous memory enabled for this chat. "
+                    f"Continuous memory enabled for {destination}. "
                     "New messages will be remembered."
                 )
             elif scope.dream_enabled:
-                response = "Continuous memory disabled for this chat. Dream remains enabled."
+                response = (
+                    f"Continuous memory disabled for {destination}. "
+                    "Dream remains enabled."
+                )
             else:
-                response = "Continuous memory disabled for this chat."
+                response = f"Continuous memory disabled for {destination}."
         else:
             enabled = command == "/ai_dream_enable"
-            identity = await self._prompt_builder.resolve_identity(message)
             await self._store.set_dream_memory_enabled(
                 scope_id,
                 enabled,
-                identity.scope_display_name,
+                target.display_name,
             )
             scope = await self._store.get_memory_scope_state(scope_id)
             if enabled and scope.continuous_enabled:
                 response = (
-                    "Dream enabled for this chat, but continuous memory "
+                    f"Dream enabled for {destination}, but continuous memory "
                     "currently overrides it."
                 )
             elif enabled:
-                response = "Dream enabled for this chat."
+                response = f"Dream enabled for {destination}."
             else:
-                response = "Dream disabled for this chat."
+                response = f"Dream disabled for {destination}."
         await self._schedule_memory_command_delete(message, command)
         await self._reply_memory_excluded(message, response, kind="memory-control")
+        return True
+
+    async def _handle_memory_scope_list(self, message: ReplyTarget) -> bool:
+        states = await self._store.list_enabled_memory_scope_states()
+        if not states:
+            response = "No chats have continuous memory or Dream enabled."
+        else:
+            header = f"Memory-enabled chats ({len(states)}):"
+            lines: list[str] = []
+            response_length = len(header)
+            for index, state in enumerate(states):
+                line = _format_memory_scope_summary(state)
+                if response_length + len(line) + 1 > 3700:
+                    lines.append(f"- ... {len(states) - index} more")
+                    break
+                lines.append(line)
+                response_length += len(line) + 1
+            response = "\n".join((header, *lines))
+        await self._schedule_memory_command_delete(message, "/ai_memory_list")
+        await self._reply_memory_excluded(
+            message,
+            response,
+            kind="memory-control",
+        )
         return True
 
     async def _continuous_memory_enabled(self, chat_id: int) -> bool:
@@ -3265,6 +3471,20 @@ def _marker_from_row(row: aiosqlite.Row) -> AIAnswerMarker:
     )
 
 
+def _memory_scope_state_from_row(row: aiosqlite.Row) -> MemoryScopeState:
+    return MemoryScopeState(
+        scope_id=str(row["scope_id"]),
+        display_name=row["resolved_display_name"],
+        continuous_enabled=bool(row["continuous_enabled"]),
+        dream_enabled=bool(row["dream_enabled"]),
+        continuous_cursor_message_id=row["continuous_cursor_message_id"],
+        continuous_last_attempt_at=row["continuous_last_attempt_at"],
+        continuous_last_success_at=row["continuous_last_success_at"],
+        continuous_last_error=row["continuous_last_error"],
+        dream_last_error=row["dream_last_error"],
+    )
+
+
 def _memory_document_receipt_from_row(
     row: aiosqlite.Row,
 ) -> MemoryDocumentReceipt:
@@ -3357,6 +3577,42 @@ def _telegram_channel_subject_id(channel_id: int) -> str:
 
 def _telegram_scope_id(chat_id: int) -> str:
     return f"telegram:chat:{chat_id}"
+
+
+def _memory_scope_target_label(target: MemoryScopeTarget) -> str:
+    if target.display_name:
+        return f"{target.display_name} ({target.chat_id})"
+    return str(target.chat_id)
+
+
+def _format_memory_scope_summary(state: MemoryScopeState) -> str:
+    chat_id = state.scope_id.removeprefix("telegram:chat:")
+    label = (
+        f"{state.display_name} ({chat_id})"
+        if state.display_name
+        else chat_id
+    )
+    if state.continuous_enabled:
+        cursor = (
+            str(state.continuous_cursor_message_id)
+            if state.continuous_cursor_message_id is not None
+            else "not started"
+        )
+        continuous = f"continuous enabled (cursor {cursor})"
+    else:
+        continuous = "continuous disabled"
+    dream = "Dream enabled" if state.dream_enabled else "Dream disabled"
+    if state.continuous_enabled and state.dream_enabled:
+        dream += " (overridden)"
+    errors = []
+    if state.continuous_last_error:
+        errors.append(f"continuous: {state.continuous_last_error}")
+    if state.dream_last_error:
+        errors.append(f"Dream: {state.dream_last_error}")
+    return (
+        f"- {label}: {continuous}; {dream}; "
+        f"errors: {'; '.join(errors) if errors else 'none'}"
+    )
 
 
 def _format_memory_time(timestamp: float | None) -> str:

--- a/src/telefire/plugins/ai.py
+++ b/src/telefire/plugins/ai.py
@@ -17,6 +17,7 @@ from telefire.ai import (
     PiAgentGateway,
     PromptBuilder,
     TelegramEditLimiter,
+    TelegramMemoryScopeTargetResolver,
     TelegramMessageIdentityResolver,
     TelegramMessageMentionResolver,
     select_telegram_response_format,
@@ -268,6 +269,10 @@ class TelegramAI(TelegramCommand, metaclass=PluginMount):
             ),
             memory=self._memory,
             dream_runner=dream_runner,
+            memory_scope_resolver=TelegramMemoryScopeTargetResolver(
+                self.client,
+                logger=self.logger,
+            ),
             memory_command_delete_delay=(
                 self._settings.memory_command_delete_delay
             ),

--- a/tests/test_ai_memory_integration.py
+++ b/tests/test_ai_memory_integration.py
@@ -21,6 +21,7 @@ from telefire.ai import (
     MemoryDreamResult,
     MemoryDreamState,
     MemoryScopeState,
+    MemoryScopeTarget,
     PromptBuilder,
     TelegramMessageIdentityResolver,
     TelegramMessageMentionResolver,
@@ -145,9 +146,11 @@ class FakeStore:
         self.memory_continuous = set()
         self.memory_dream = set()
         self.memory_continuous_cursors = {}
+        self.memory_continuous_errors = {}
         self.memory_excluded = set()
         self.memory_dream_state = {}
         self.memory_labels = {}
+        self.memory_scope_display_names = {}
 
     async def get_answer(self, chat_id, answer_message_id):
         return self.markers.get((chat_id, answer_message_id))
@@ -222,11 +225,30 @@ class FakeStore:
         }
 
     async def get_memory_scope_state(self, scope_id):
+        dream_state = self.memory_dream_state.get(scope_id)
         return MemoryScopeState(
             scope_id=scope_id,
+            display_name=self.memory_scope_display_names.get(scope_id),
             continuous_enabled=scope_id in self.memory_continuous,
             dream_enabled=scope_id in self.memory_dream,
             continuous_cursor_message_id=self.memory_continuous_cursors.get(scope_id),
+            continuous_last_error=self.memory_continuous_errors.get(scope_id),
+            dream_last_error=dream_state.last_error if dream_state else None,
+        )
+
+    async def list_enabled_memory_scope_states(self):
+        scope_ids = self.memory_continuous | self.memory_dream
+        return tuple(
+            [
+                await self.get_memory_scope_state(scope_id)
+                for scope_id in sorted(
+                    scope_ids,
+                    key=lambda item: (
+                        (self.memory_scope_display_names.get(item) or "").casefold(),
+                        item,
+                    ),
+                )
+            ]
         )
 
     async def set_continuous_memory_enabled(
@@ -241,6 +263,8 @@ class FakeStore:
             self.memory_continuous_cursors.setdefault(scope_id, cursor_message_id)
         else:
             self.memory_continuous.discard(scope_id)
+        if display_name:
+            self.memory_scope_display_names[scope_id] = display_name
 
     async def set_dream_memory_enabled(
         self,
@@ -252,6 +276,8 @@ class FakeStore:
             self.memory_dream.add(scope_id)
         else:
             self.memory_dream.discard(scope_id)
+        if display_name:
+            self.memory_scope_display_names[scope_id] = display_name
 
     async def mark_memory_excluded_message(self, chat_id, message_id, kind):
         self.memory_excluded.add((chat_id, message_id, kind))
@@ -377,6 +403,19 @@ class FakeMentionResolver:
         )
 
 
+class FakeMemoryScopeResolver:
+    def __init__(self, targets=None, error=None):
+        self.targets = targets or {}
+        self.error = error
+        self.calls = []
+
+    async def resolve(self, chat_id, *, include_latest_message=False):
+        self.calls.append((chat_id, include_latest_message))
+        if self.error is not None:
+            raise self.error
+        return self.targets[chat_id]
+
+
 class FakeTelegramIdentityMessage:
     async def get_sender(self):
         return telegram_types.User(
@@ -440,6 +479,7 @@ def make_handler(
     history_source=None,
     store=None,
     dream_runner=None,
+    memory_scope_resolver=None,
     memory_command_delete_delay=0,
 ):
     store = store or FakeStore(allowed=allowed)
@@ -456,6 +496,7 @@ def make_handler(
         rate_limiter=AIRateLimiter(store, cooldown_seconds=0),
         memory=memory,
         dream_runner=dream_runner,
+        memory_scope_resolver=memory_scope_resolver,
         memory_command_delete_delay=memory_command_delete_delay,
         logger=logger,
     )
@@ -1228,6 +1269,235 @@ async def test_owner_controls_continuous_and_dream_memory_independently():
 
 
 @pytest.mark.asyncio
+async def test_owner_can_enable_continuous_memory_for_remote_channel():
+    store = FakeStore()
+    resolver = FakeMemoryScopeResolver(
+        {
+            -1002064685671: MemoryScopeTarget(
+                chat_id=-1002064685671,
+                display_name="Seele Leaks",
+                latest_message_id=33392,
+            )
+        }
+    )
+    handler = make_handler(
+        FakeGateway(["unused"]),
+        FakeMemory(),
+        store=store,
+        memory_scope_resolver=resolver,
+    )
+    command = FakeMessage(
+        "/ai_memory_enable -1002064685671",
+        sender_id=10,
+        chat_id=10,
+    )
+
+    assert await handler.handle(command) is True
+
+    scope_id = "telegram:chat:-1002064685671"
+    assert resolver.calls == [(-1002064685671, True)]
+    assert scope_id in store.memory_continuous
+    assert store.memory_continuous_cursors[scope_id] == 33392
+    assert store.memory_scope_display_names[scope_id] == "Seele Leaks"
+    assert command.deleted is True
+    assert command.replies[0].text == (
+        "Continuous memory enabled for Seele Leaks (-1002064685671). "
+        "New messages will be remembered."
+    )
+
+
+@pytest.mark.asyncio
+async def test_owner_can_disable_continuous_memory_for_remote_channel():
+    scope_id = "telegram:chat:-1002064685671"
+    store = FakeStore()
+    store.memory_continuous.add(scope_id)
+    resolver = FakeMemoryScopeResolver(
+        {
+            -1002064685671: MemoryScopeTarget(
+                chat_id=-1002064685671,
+                display_name="Seele Leaks",
+            )
+        }
+    )
+    handler = make_handler(
+        FakeGateway(["unused"]),
+        FakeMemory(),
+        store=store,
+        memory_scope_resolver=resolver,
+    )
+    command = FakeMessage(
+        "/ai_memory_disable -1002064685671",
+        sender_id=10,
+        chat_id=10,
+    )
+
+    assert await handler.handle(command) is True
+
+    assert resolver.calls == [(-1002064685671, False)]
+    assert scope_id not in store.memory_continuous
+    assert command.deleted is True
+    assert command.replies[0].text == (
+        "Continuous memory disabled for Seele Leaks (-1002064685671)."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command_text", "enabled"),
+    [
+        ("/ai_dream_enable -1002064685671", True),
+        ("/ai_dream_disable -1002064685671", False),
+    ],
+)
+async def test_owner_can_control_dream_for_remote_channel(command_text, enabled):
+    scope_id = "telegram:chat:-1002064685671"
+    store = FakeStore()
+    store.memory_dream.add(scope_id)
+    resolver = FakeMemoryScopeResolver(
+        {
+            -1002064685671: MemoryScopeTarget(
+                chat_id=-1002064685671,
+                display_name="Seele Leaks",
+            )
+        }
+    )
+    handler = make_handler(
+        FakeGateway(["unused"]),
+        FakeMemory(),
+        store=store,
+        memory_scope_resolver=resolver,
+    )
+    command = FakeMessage(command_text, sender_id=10, chat_id=10)
+
+    assert await handler.handle(command) is True
+
+    assert resolver.calls == [(-1002064685671, False)]
+    assert (scope_id in store.memory_dream) is enabled
+    assert command.deleted is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command_text", "expected"),
+    [
+        (
+            "/ai_memory_enable not-an-id",
+            "Usage: /ai_memory_enable [numeric group/channel ID]",
+        ),
+        (
+            "/ai_dream_enable -1001 extra",
+            "Usage: /ai_dream_enable [numeric group/channel ID]",
+        ),
+    ],
+)
+async def test_remote_memory_commands_reject_invalid_target_syntax(
+    command_text,
+    expected,
+):
+    resolver = FakeMemoryScopeResolver()
+    handler = make_handler(
+        FakeGateway(["unused"]),
+        FakeMemory(),
+        memory_scope_resolver=resolver,
+    )
+    command = FakeMessage(command_text, sender_id=10)
+
+    assert await handler.handle(command) is True
+
+    assert resolver.calls == []
+    assert command.deleted is False
+    assert command.replies[0].text == expected
+
+
+@pytest.mark.asyncio
+async def test_remote_memory_command_reports_inaccessible_target():
+    resolver = FakeMemoryScopeResolver(error=ValueError("not accessible"))
+    handler = make_handler(
+        FakeGateway(["unused"]),
+        FakeMemory(),
+        memory_scope_resolver=resolver,
+    )
+    command = FakeMessage(
+        "/ai_memory_enable -1002064685671",
+        sender_id=10,
+        chat_id=10,
+    )
+
+    assert await handler.handle(command) is True
+
+    assert command.deleted is False
+    assert command.replies[0].text == (
+        "Unable to access that Telegram group/channel. "
+        "Check the numeric chat ID and this account's access."
+    )
+
+
+@pytest.mark.asyncio
+async def test_owner_can_list_all_enabled_memory_scopes():
+    store = FakeStore()
+    store.memory_continuous.update(
+        {"telegram:chat:-1001", "telegram:chat:-3003"}
+    )
+    store.memory_dream.update(
+        {"telegram:chat:-1001", "telegram:chat:-2002"}
+    )
+    store.memory_scope_display_names.update(
+        {
+            "telegram:chat:-1001": "Engineering Group",
+            "telegram:chat:-2002": "Dream Only",
+            "telegram:chat:-3003": "Continuous Only",
+        }
+    )
+    store.memory_continuous_cursors.update(
+        {
+            "telegram:chat:-1001": 51,
+            "telegram:chat:-3003": 88,
+        }
+    )
+    store.memory_continuous_errors["telegram:chat:-3003"] = "flood wait"
+    store.memory_dream_state["telegram:chat:-2002"] = MemoryDreamState(
+        scope_id="telegram:chat:-2002",
+        last_error="temporary backpressure",
+    )
+    handler = make_handler(
+        FakeGateway(["unused"]),
+        FakeMemory(),
+        store=store,
+    )
+    command = FakeMessage("/ai_memory_list", sender_id=10, chat_id=10)
+
+    assert await handler.handle(command) is True
+
+    assert command.deleted is True
+    assert command.replies[0].text == (
+        "Memory-enabled chats (3):\n"
+        "- Continuous Only (-3003): continuous enabled (cursor 88); "
+        "Dream disabled; errors: continuous: flood wait\n"
+        "- Dream Only (-2002): continuous disabled; Dream enabled; "
+        "errors: Dream: temporary backpressure\n"
+        "- Engineering Group (-1001): continuous enabled (cursor 51); "
+        "Dream enabled (overridden); errors: none"
+    )
+
+
+@pytest.mark.asyncio
+async def test_memory_scope_list_reports_when_no_modes_are_enabled():
+    handler = make_handler(
+        FakeGateway(["unused"]),
+        FakeMemory(),
+        store=FakeStore(),
+    )
+    command = FakeMessage("/ai_memory_list", sender_id=10, chat_id=10)
+
+    assert await handler.handle(command) is True
+
+    assert command.deleted is True
+    assert command.replies[0].text == (
+        "No chats have continuous memory or Dream enabled."
+    )
+
+
+@pytest.mark.asyncio
 async def test_enabled_continuation_retains_human_chain_across_ai_answer():
     store = FakeStore()
     memory = FakeMemory(recall_result=MemoryRecall("telegram:chat:-1001", ()))
@@ -1335,10 +1605,20 @@ async def test_failed_agent_run_does_not_retain_enabled_scope():
 @pytest.mark.asyncio
 async def test_non_owner_cannot_change_scope_memory_state():
     store = FakeStore(allowed={20})
-    handler = make_handler(FakeGateway(["unused"]), FakeMemory(), store=store)
-    command = FakeMessage("/ai_memory_enable", sender_id=20)
+    resolver = FakeMemoryScopeResolver()
+    handler = make_handler(
+        FakeGateway(["unused"]),
+        FakeMemory(),
+        store=store,
+        memory_scope_resolver=resolver,
+    )
+    command = FakeMessage(
+        "/ai_memory_enable -1002064685671",
+        sender_id=20,
+    )
 
     assert await handler.handle(command) is False
+    assert resolver.calls == []
     assert command.replies == []
     assert command.deleted is False
     assert store.memory_continuous == set()
@@ -1407,6 +1687,7 @@ async def test_memory_scope_modes_persist_across_repository_restart(tmp_path):
             "telegram:chat:-1001"
         ) == MemoryScopeState(
             scope_id="telegram:chat:-1001",
+            display_name="Engineering Group",
             continuous_enabled=True,
             dream_enabled=True,
             continuous_cursor_message_id=41,
@@ -1416,6 +1697,48 @@ async def test_memory_scope_modes_persist_across_repository_restart(tmp_path):
         ) == MemoryScopeState(scope_id="telegram:chat:-2002")
     finally:
         await second.close()
+
+
+@pytest.mark.asyncio
+async def test_repository_lists_only_enabled_memory_scopes_with_labels(tmp_path):
+    store = await AIStateRepository(tmp_path / "ai.db").connect()
+    try:
+        await store.set_continuous_memory_enabled(
+            "telegram:chat:-3003",
+            True,
+            "Zulu Chat",
+            cursor_message_id=88,
+        )
+        await store.set_dream_memory_enabled(
+            "telegram:chat:-2002",
+            True,
+        )
+        await store.record_memory_labels(
+            "telegram:chat:-2002",
+            "Alpha Chat",
+            {},
+        )
+        await store.set_dream_memory_enabled(
+            "telegram:chat:-4004",
+            False,
+            "Disabled Chat",
+        )
+
+        assert await store.list_enabled_memory_scope_states() == (
+            MemoryScopeState(
+                scope_id="telegram:chat:-2002",
+                display_name="Alpha Chat",
+                dream_enabled=True,
+            ),
+            MemoryScopeState(
+                scope_id="telegram:chat:-3003",
+                display_name="Zulu Chat",
+                continuous_enabled=True,
+                continuous_cursor_message_id=88,
+            ),
+        )
+    finally:
+        await store.close()
 
 
 @pytest.mark.asyncio
@@ -1447,6 +1770,7 @@ async def test_legacy_enabled_scope_migrates_to_dream_only(tmp_path):
             "telegram:chat:-1001"
         ) == MemoryScopeState(
             scope_id="telegram:chat:-1001",
+            display_name="Engineering Group",
             continuous_enabled=False,
             dream_enabled=True,
         )

--- a/tests/test_ai_plugin.py
+++ b/tests/test_ai_plugin.py
@@ -6,7 +6,12 @@ from telethon import utils as telegram_utils
 from telethon.tl import functions as telegram_functions
 from telethon.tl import types as telegram_types
 
-from telefire.plugins.ai import TelegramAI, _parse_telegram_message_link
+from telefire.ai import MemoryScopeTarget
+from telefire.plugins.ai import (
+    TelegramAI,
+    TelegramMemoryScopeTargetResolver,
+    _parse_telegram_message_link,
+)
 
 
 class FailingHandler:
@@ -118,6 +123,22 @@ class FakeTelegramClient:
         if self.request_error is not None:
             raise self.request_error
         return SimpleNamespace()
+
+
+class FakeMemoryScopeClient:
+    def __init__(self, entity, latest_messages=()):
+        self.entity = entity
+        self.latest_messages = latest_messages
+        self.get_entity_calls = []
+        self.get_messages_calls = []
+
+    async def get_entity(self, candidate):
+        self.get_entity_calls.append(candidate)
+        return self.entity
+
+    async def get_messages(self, entity, *, limit):
+        self.get_messages_calls.append((entity, limit))
+        return self.latest_messages
 
 
 class FakeSavedMessage:
@@ -240,6 +261,47 @@ def test_parse_telegram_message_link(
 )
 def test_parse_telegram_message_link_rejects_non_message_links(text):
     assert _parse_telegram_message_link(text) is None
+
+
+@pytest.mark.asyncio
+async def test_memory_scope_target_resolver_resolves_channel_and_latest_message():
+    channel = telegram_types.Channel(
+        id=2064685671,
+        title="Seele Leaks",
+        photo=telegram_types.ChatPhotoEmpty(),
+        date=None,
+        broadcast=True,
+    )
+    client = FakeMemoryScopeClient(
+        channel,
+        latest_messages=[SimpleNamespace(id=33392)],
+    )
+    resolver = TelegramMemoryScopeTargetResolver(client)
+
+    target = await resolver.resolve(
+        -1002064685671,
+        include_latest_message=True,
+    )
+
+    assert target == MemoryScopeTarget(
+        chat_id=-1002064685671,
+        display_name="Seele Leaks",
+        latest_message_id=33392,
+    )
+    assert client.get_entity_calls == [-1002064685671]
+    assert client.get_messages_calls == [(channel, 1)]
+
+
+@pytest.mark.asyncio
+async def test_memory_scope_target_resolver_rejects_users():
+    user = telegram_types.User(id=20, first_name="Alice")
+    client = FakeMemoryScopeClient(user)
+    resolver = TelegramMemoryScopeTargetResolver(client)
+
+    with pytest.raises(ValueError, match="group or channel"):
+        await resolver.resolve(20)
+
+    assert client.get_messages_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add owner-only /ai_memory_list status reporting for every enabled chat or channel
- allow continuous-memory and Dream enable/disable commands to target an optional numeric Telegram chat ID
- resolve canonical Telegram identities and seed remote continuous capture after the target's latest message

## Verification
- uv run pytest -q (246 passed, 6 skipped)
- uv build
- uv run python -m compileall -q src tests
- git diff --check