### PR TITLE
Refactor AI commands behind chat-neutral adapters

### DIFF
--- a/src/telefire/ai.py
+++ b/src/telefire/ai.py
@@ -30,6 +30,19 @@ from telefire.ai_attachments import (
     AttachmentAnalysisRequest,
 )
 from telefire.chat.attachments import AttachmentDescriber, AttachmentDescription
+from telefire.chat.commands import (
+    AIAskCommand,
+    AICancelCommand,
+    AccessCommand,
+    InvalidCommand,
+    MemoryBackfillCommand,
+    MemoryDreamCommand,
+    MemoryListCommand,
+    MemoryModeCommand,
+    MemoryRememberCommand,
+    MemoryStatusCommand,
+    parse_chat_command,
+)
 from telefire.chat.transport import ChatTransport, ObjectChatTransport
 
 
@@ -42,8 +55,6 @@ AgentEventType = Literal[
     "run_failed",
 ]
 MAX_AGENT_MEMORY_ANCHORS = 64
-MAX_MEMORY_BACKFILL_DAYS = 30
-MAX_MEMORY_BACKFILL_MESSAGES = 5_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -283,7 +294,7 @@ class MessageMentionResolver(Protocol):
 class MemoryScopeTargetResolver(Protocol):
     async def resolve(
         self,
-        chat_id: int,
+        target: str,
         *,
         include_latest_message: bool = False,
     ) -> MemoryScopeTarget: ...
@@ -395,10 +406,19 @@ class TelegramMemoryScopeTargetResolver:
 
     async def resolve(
         self,
-        chat_id: int,
+        target: str,
         *,
         include_latest_message: bool = False,
     ) -> MemoryScopeTarget:
+        digits = target.removeprefix("-")
+        if (
+            not digits
+            or not digits.isascii()
+            or not digits.isdecimal()
+            or int(target) == 0
+        ):
+            raise ValueError("Telegram target must be a non-zero numeric chat ID")
+        chat_id = int(target)
         try:
             entity = await self._client.get_entity(chat_id)
             if not isinstance(
@@ -549,28 +569,13 @@ class MemoryDreamResult:
     documents_unchanged: int
 
 
-@dataclass(frozen=True, slots=True)
-class MemoryBackfillRequest:
-    mode: Literal["days", "messages"]
-    value: int
-
-    def __post_init__(self) -> None:
-        limit = (
-            MAX_MEMORY_BACKFILL_DAYS
-            if self.mode == "days"
-            else MAX_MEMORY_BACKFILL_MESSAGES
-        )
-        if self.mode not in {"days", "messages"} or not 1 <= self.value <= limit:
-            raise ValueError("Memory backfill request is outside its supported bounds")
-
-
 class MemoryDreamRunner(Protocol):
     async def run_scope(self, chat_id: int) -> MemoryDreamResult: ...
 
     async def run_backfill(
         self,
         chat_id: int,
-        request: MemoryBackfillRequest,
+        request: MemoryBackfillCommand,
     ) -> MemoryDreamResult: ...
 
 
@@ -681,12 +686,6 @@ class HumanObservation:
 
 
 @dataclass(frozen=True, slots=True)
-class AITrigger:
-    prompt: str
-    recent_messages: int | None = None
-
-
-@dataclass(frozen=True, slots=True)
 class ChatContextMessage:
     message_id: int
     chat_id: int | None
@@ -712,98 +711,12 @@ class MemoryChainRetain:
     created: bool
 
 
-def parse_ai_trigger(text: str | None) -> AITrigger | None:
-    if text is None:
-        return None
-    if not text.casefold().startswith("/ai"):
-        return None
-    cursor = 3
-    digit_start = cursor
-    while cursor < len(text) and text[cursor].isascii() and text[cursor].isdigit():
-        cursor += 1
-    recent_messages = (
-        int(text[digit_start:cursor]) if cursor > digit_start else None
-    )
-    if cursor < len(text) and text[cursor] == "@":
-        cursor += 1
-        mention_start = cursor
-        while cursor < len(text) and text[cursor] not in {
-            " ",
-            "\n",
-            "\t",
-            "\r",
-        }:
-            cursor += 1
-        if cursor == mention_start:
-            return None
-    if cursor == len(text):
-        return AITrigger(prompt="", recent_messages=recent_messages)
-    if text[cursor] not in {" ", "\n", "\t", "\r"}:
-        return None
-    return AITrigger(
-        prompt=text[cursor:].strip(),
-        recent_messages=recent_messages,
-    )
-
-
-def parse_memory_revision(text: str | None) -> str | None:
-    if text is None:
-        return None
-    if text == "/ai_memory":
-        return ""
-    if text.startswith(("/ai_memory ", "/ai_memory\n", "/ai_memory\t")):
-        return text[len("/ai_memory") :].strip()
-    return None
-
-
-def parse_memory_backfill(text: str | None) -> MemoryBackfillRequest | None:
-    if text is None:
-        return None
-    parts = text.split()
-    if len(parts) != 3 or parts[0] != "/ai_memory_backfill":
-        return None
-    if parts[1] == "days":
-        mode: Literal["days", "messages"] = "days"
-    elif parts[1] == "messages":
-        mode = "messages"
-    else:
-        return None
-    try:
-        value = int(parts[2])
-        return MemoryBackfillRequest(mode=mode, value=value)
-    except ValueError:
-        return None
-
-
-def _parse_optional_memory_scope_target(
-    text: str,
-    command: str,
-) -> tuple[bool, int | None]:
-    parts = text.split()
-    if parts == [command]:
-        return True, None
-    if len(parts) != 2 or parts[0] != command:
-        return False, None
-    candidate = parts[1]
-    digits = candidate.removeprefix("-")
-    if not digits or not digits.isascii() or not digits.isdecimal():
-        return False, None
-    chat_id = int(candidate)
-    return (True, chat_id) if chat_id != 0 else (False, None)
-
-
 def _memory_message_text(text: str) -> str:
     text = text.strip()
-    if parse_memory_revision(text) is not None:
-        return ""
-    if text.startswith(("/ai_memory_", "/ai_dream_")) or text in {
-        "/ai_allow",
-        "/ai_deny",
-        "/ai_cancel",
-    }:
-        return ""
-    trigger = parse_ai_trigger(text)
-    return trigger.prompt if trigger is not None else text
+    command = parse_chat_command(text)
+    if isinstance(command, AIAskCommand):
+        return command.prompt
+    return text if command is None else ""
 
 
 class AIResponder:
@@ -2358,81 +2271,69 @@ class AIConversationHandler:
     async def handle(self, message: ReplyTarget) -> bool:
         if message.sender_id is None or message.chat_id is None:
             return False
-        command = (message.raw_text or "").strip()
-        command_name = command.split(maxsplit=1)[0] if command else ""
+        command = parse_chat_command(message.raw_text)
         is_owner_control = (
             message.sender_id == self._owner_id
             or self._transport.is_outgoing(message)
         )
-        memory_instruction = parse_memory_revision(message.raw_text)
-        if memory_instruction is not None:
+        if isinstance(command, MemoryRememberCommand):
             if not is_owner_control:
                 return False
             return await self._handle_memory_command(
                 message,
-                memory_instruction,
+                command.instruction,
             )
-        if command_name == "/ai_memory_backfill":
+        if isinstance(command, InvalidCommand):
             if not is_owner_control:
                 return False
-            request = parse_memory_backfill(command)
-            if request is None:
+            if command.name == "/ai_memory_backfill":
                 await self._reply_memory_excluded(
                     message,
                     "Usage: /ai_memory_backfill days <1-30> or "
                     "/ai_memory_backfill messages <1-5000>",
                     kind="memory-control",
                 )
-                return True
-            return await self._handle_memory_backfill(message, request)
-        if command_name in {
-            "/ai_memory_enable",
-            "/ai_memory_disable",
-            "/ai_dream_enable",
-            "/ai_dream_disable",
-        }:
-            if not is_owner_control:
-                return False
-            valid_target, target_chat_id = _parse_optional_memory_scope_target(
-                command,
-                command_name,
-            )
-            if not valid_target:
+            else:
                 await self._reply_memory_excluded(
                     message,
-                    f"Usage: {command_name} [numeric group/channel ID]",
+                    f"Usage: {command.name} [chat target]",
                     kind="memory-control",
                 )
-                return True
-            return await self._handle_memory_scope_command(
-                message,
-                command_name,
-                target_chat_id=target_chat_id,
-            )
-        if command in {
-            "/ai_memory_status",
-            "/ai_memory_list",
-            "/ai_memory_dream",
-        }:
+            return True
+        if isinstance(command, MemoryBackfillCommand):
             if not is_owner_control:
                 return False
-            if command == "/ai_memory_dream":
-                return await self._handle_memory_dream(message)
-            if command == "/ai_memory_list":
-                return await self._handle_memory_scope_list(message)
+            return await self._handle_memory_backfill(message, command)
+        if isinstance(command, MemoryModeCommand):
+            if not is_owner_control:
+                return False
             return await self._handle_memory_scope_command(message, command)
-        if command in {"/ai_allow", "/ai_deny"}:
+        if isinstance(command, MemoryStatusCommand):
+            if not is_owner_control:
+                return False
+            return await self._handle_memory_scope_status(message)
+        if isinstance(command, MemoryListCommand):
+            if not is_owner_control:
+                return False
+            return await self._handle_memory_scope_list(message)
+        if isinstance(command, MemoryDreamCommand):
+            if not is_owner_control:
+                return False
+            return await self._handle_memory_dream(message)
+        if isinstance(command, AccessCommand):
             if not is_owner_control:
                 return False
             return await self._handle_access_command(message, command)
 
         is_owner = message.sender_id == self._owner_id
-        if command == "/ai_cancel":
+        if isinstance(command, AICancelCommand):
             if not is_owner and not await self._store.is_allowed(message.sender_id):
                 return False
             return await self._handle_cancel(message)
 
-        ai_trigger = parse_ai_trigger(message.raw_text)
+        ai_trigger = command if isinstance(command, AIAskCommand) else None
+        if command is not None and ai_trigger is None:
+            return False
         if ai_trigger is None and message.reply_to_msg_id is None:
             return False
 
@@ -2698,13 +2599,13 @@ class AIConversationHandler:
     async def _handle_access_command(
         self,
         message: ReplyTarget,
-        command: str,
+        command: AccessCommand,
     ) -> bool:
         target = await self._transport.get_reply(message)
         if target is None or target.sender_id is None:
             await self._reply_memory_excluded(
                 message,
-                f"Usage: reply to a user with {command}",
+                f"Usage: reply to a user with {command.name}",
                 kind="ai-control",
             )
             return True
@@ -2714,83 +2615,46 @@ class AIConversationHandler:
                 "Owner access is always enabled.",
                 kind="ai-control",
             )
-            await self._delete_command_message(message, command)
+            await self._delete_command_message(message, command.name)
             return True
-        if command == "/ai_allow":
+        if command.allowed:
             await self._store.allow_user(target.sender_id)
             response = "AI access allowed."
         else:
             await self._store.deny_user(target.sender_id)
             response = "AI access denied."
         await self._reply_memory_excluded(message, response, kind="ai-control")
-        await self._delete_command_message(message, command)
+        await self._delete_command_message(message, command.name)
         return True
 
     async def _handle_memory_scope_command(
         self,
         message: ReplyTarget,
-        command: str,
-        *,
-        target_chat_id: int | None = None,
+        command: MemoryModeCommand,
     ) -> bool:
         assert message.chat_id is not None
-        if command == "/ai_memory_status":
-            scope_id = _telegram_scope_id(message.chat_id)
-            scope = await self._store.get_memory_scope_state(scope_id)
-            state = await self._store.get_memory_dream_state(scope_id)
-            dream_status = "enabled" if scope.dream_enabled else "disabled"
-            if scope.continuous_enabled and scope.dream_enabled:
-                dream_status += " (overridden by continuous memory)"
-            response = "\n".join(
-                (
-                    "Continuous memory: "
-                    + ("enabled" if scope.continuous_enabled else "disabled"),
-                    f"Dream: {dream_status}",
-                    "Continuous cursor: "
-                    + (
-                        str(scope.continuous_cursor_message_id)
-                        if scope.continuous_cursor_message_id is not None
-                        else "not started"
-                    ),
-                    "Last continuous attempt: "
-                    f"{_format_memory_time(scope.continuous_last_attempt_at)}",
-                    "Last continuous success: "
-                    f"{_format_memory_time(scope.continuous_last_success_at)}",
-                    "Last continuous error: "
-                    f"{scope.continuous_last_error or 'none'}",
-                    f"Last Dream attempt: {_format_memory_time(state.last_attempt_at)}",
-                    f"Last Dream success: {_format_memory_time(state.last_success_at)}",
-                    f"Last Dream error: {state.last_error or 'none'}",
-                )
-            )
-            await self._schedule_memory_command_delete(message, command)
-            await self._reply_memory_excluded(
-                message,
-                response,
-                kind="memory-control",
-            )
-            return True
-
-        is_remote = target_chat_id is not None
+        is_remote = command.target is not None
         if is_remote:
             if self._memory_scope_resolver is None:
                 await self._reply_memory_excluded(
                     message,
-                    "Remote Telegram group/channel lookup is unavailable.",
+                    "Remote chat lookup is unavailable.",
                     kind="memory-control",
                 )
                 return True
             try:
                 target = await self._memory_scope_resolver.resolve(
-                    target_chat_id,
-                    include_latest_message=command == "/ai_memory_enable",
+                    command.target,
+                    include_latest_message=(
+                        command.mode == "continuous" and command.enabled
+                    ),
                 )
             except Exception as exc:
                 self._log_memory_failure("scope lookup", exc)
                 await self._reply_memory_excluded(
                     message,
-                    "Unable to access that Telegram group/channel. "
-                    "Check the numeric chat ID and this account's access.",
+                    "Unable to access that chat target. "
+                    "Check its identifier and this account's access.",
                     kind="memory-control",
                 )
                 return True
@@ -2805,16 +2669,17 @@ class AIConversationHandler:
         scope_id = _telegram_scope_id(target.chat_id)
         target_label = _memory_scope_target_label(target)
         destination = target_label if is_remote else "this chat"
-        if command in {"/ai_memory_enable", "/ai_memory_disable"}:
-            enabled = command == "/ai_memory_enable"
+        if command.mode == "continuous":
             await self._store.set_continuous_memory_enabled(
                 scope_id,
-                enabled,
+                command.enabled,
                 target.display_name,
-                cursor_message_id=target.latest_message_id if enabled else None,
+                cursor_message_id=(
+                    target.latest_message_id if command.enabled else None
+                ),
             )
             scope = await self._store.get_memory_scope_state(scope_id)
-            if enabled:
+            if command.enabled:
                 response = (
                     f"Continuous memory enabled for {destination}. "
                     "New messages will be remembered."
@@ -2827,24 +2692,64 @@ class AIConversationHandler:
             else:
                 response = f"Continuous memory disabled for {destination}."
         else:
-            enabled = command == "/ai_dream_enable"
             await self._store.set_dream_memory_enabled(
                 scope_id,
-                enabled,
+                command.enabled,
                 target.display_name,
             )
             scope = await self._store.get_memory_scope_state(scope_id)
-            if enabled and scope.continuous_enabled:
+            if command.enabled and scope.continuous_enabled:
                 response = (
                     f"Dream enabled for {destination}, but continuous memory "
                     "currently overrides it."
                 )
-            elif enabled:
+            elif command.enabled:
                 response = f"Dream enabled for {destination}."
             else:
                 response = f"Dream disabled for {destination}."
-        await self._schedule_memory_command_delete(message, command)
+        await self._schedule_memory_command_delete(message, command.name)
         await self._reply_memory_excluded(message, response, kind="memory-control")
+        return True
+
+    async def _handle_memory_scope_status(self, message: ReplyTarget) -> bool:
+        assert message.chat_id is not None
+        scope_id = _telegram_scope_id(message.chat_id)
+        scope = await self._store.get_memory_scope_state(scope_id)
+        state = await self._store.get_memory_dream_state(scope_id)
+        dream_status = "enabled" if scope.dream_enabled else "disabled"
+        if scope.continuous_enabled and scope.dream_enabled:
+            dream_status += " (overridden by continuous memory)"
+        response = "\n".join(
+            (
+                "Continuous memory: "
+                + ("enabled" if scope.continuous_enabled else "disabled"),
+                f"Dream: {dream_status}",
+                "Continuous cursor: "
+                + (
+                    str(scope.continuous_cursor_message_id)
+                    if scope.continuous_cursor_message_id is not None
+                    else "not started"
+                ),
+                "Last continuous attempt: "
+                f"{_format_memory_time(scope.continuous_last_attempt_at)}",
+                "Last continuous success: "
+                f"{_format_memory_time(scope.continuous_last_success_at)}",
+                "Last continuous error: "
+                f"{scope.continuous_last_error or 'none'}",
+                f"Last Dream attempt: {_format_memory_time(state.last_attempt_at)}",
+                f"Last Dream success: {_format_memory_time(state.last_success_at)}",
+                f"Last Dream error: {state.last_error or 'none'}",
+            )
+        )
+        await self._schedule_memory_command_delete(
+            message,
+            "/ai_memory_status",
+        )
+        await self._reply_memory_excluded(
+            message,
+            response,
+            kind="memory-control",
+        )
         return True
 
     async def _handle_memory_scope_list(self, message: ReplyTarget) -> bool:
@@ -2931,7 +2836,7 @@ class AIConversationHandler:
     async def _handle_memory_backfill(
         self,
         message: ReplyTarget,
-        request: MemoryBackfillRequest,
+        request: MemoryBackfillCommand,
     ) -> bool:
         assert message.chat_id is not None
         await self._schedule_memory_command_delete(message, "/ai_memory_backfill")

--- a/src/telefire/ai.py
+++ b/src/telefire/ai.py
@@ -35,6 +35,7 @@ from telefire.ai_attachments import (
     AttachmentDescription,
     message_has_attachment,
 )
+from telefire.chat.transport import ChatTransport
 
 
 TelegramResponseFormat = Literal["regular_html", "rich_markdown"]
@@ -921,9 +922,11 @@ class AIResponder:
         response_format: TelegramResponseFormat = "regular_html",
         clock: Callable[[], float] = time.monotonic,
         edit_limiter: TelegramEditLimiter | None = None,
+        transport: ChatTransport | None = None,
         logger: Any | None = None,
     ):
         self._gateway = gateway
+        self._transport = transport
         self._response_format = response_format
         self._edit_limiter = edit_limiter or TelegramEditLimiter(
             edit_cadence,
@@ -936,7 +939,15 @@ class AIResponder:
     async def answer(
         self, trigger: ReplyTarget, request: AgentRunRequest
     ) -> AnswerResult:
-        answer = await trigger.reply("Thinking...", parse_mode=None)
+        answer = (
+            await self._transport.reply(
+                trigger,
+                "Thinking...",
+                presentation="plain",
+            )
+            if self._transport is not None
+            else await trigger.reply("Thinking...", parse_mode=None)
+        )
         text = ""
         last_edited_source: str | None = None
         session_id: str | None = None
@@ -1049,6 +1060,13 @@ class AIResponder:
         *,
         wait: bool,
     ) -> bool:
+        if self._transport is not None:
+            return await self._transport.update(
+                answer,
+                text,
+                presentation="agent",
+                wait=wait,
+            )
         if self._response_format == "rich_markdown":
             return await self._edit_rich_markdown(answer, text, wait=wait)
         rendered, entities = telegram_html.parse(text)
@@ -1070,6 +1088,13 @@ class AIResponder:
         wait: bool,
         **kwargs: Any,
     ) -> bool:
+        if self._transport is not None:
+            return await self._transport.update(
+                answer,
+                text,
+                presentation="plain",
+                wait=wait,
+            )
         return await self._edit_limiter.run(
             lambda: answer.edit(text, **kwargs),
             wait=wait,

--- a/src/telefire/ai.py
+++ b/src/telefire/ai.py
@@ -14,9 +14,6 @@ from uuid import uuid4
 
 import aiosqlite
 import aiohttp
-from telethon import helpers as telegram_helpers
-from telethon import utils as telegram_utils
-from telethon.tl import types as telegram_types
 
 from telefire.ai_memory import (
     MemoryClient,
@@ -43,6 +40,7 @@ from telefire.chat.commands import (
     MemoryStatusCommand,
     parse_chat_command,
 )
+from telefire.chat.identity import IdentityCodec, NamespacedIdentityCodec
 from telefire.chat.transport import ChatTransport, ObjectChatTransport
 
 
@@ -307,147 +305,6 @@ class MessageHistorySource(Protocol):
         *,
         limit: int,
     ) -> tuple[ReplyTarget, ...]: ...
-
-
-class TelegramMessageIdentityResolver:
-    def __init__(self, *, logger: Any | None = None):
-        self._logger = logger
-
-    async def resolve(self, message: ReplyTarget) -> MessageIdentity:
-        sender, chat = await asyncio.gather(
-            self._load_entity(message, "get_sender"),
-            self._load_entity(message, "get_chat"),
-        )
-        is_human = (
-            isinstance(sender, telegram_types.User)
-            and not bool(getattr(sender, "bot", False))
-        )
-        is_broadcast_channel_post = (
-            isinstance(sender, telegram_types.Channel)
-            and isinstance(chat, telegram_types.Channel)
-            and bool(getattr(chat, "broadcast", False))
-            and sender.id == chat.id
-        )
-        return MessageIdentity(
-            subject_id=(
-                _telegram_subject_id(sender.id)
-                if is_human
-                else _telegram_channel_subject_id(sender.id)
-                if is_broadcast_channel_post
-                else None
-            ),
-            subject_display_name=_telegram_display_name(sender),
-            scope_display_name=_telegram_display_name(chat),
-            is_human=is_human,
-        )
-
-    async def _load_entity(self, message: ReplyTarget, method_name: str) -> Any | None:
-        method = getattr(message, method_name, None)
-        if not callable(method):
-            return None
-        try:
-            return await method()
-        except Exception as exc:
-            if self._logger is not None:
-                self._logger.debug(
-                    "Telegram identity lookup failed (%s): %s",
-                    type(exc).__name__,
-                    exc,
-                )
-            return None
-
-
-class TelegramMessageMentionResolver:
-    def __init__(self, client: Any, *, logger: Any | None = None):
-        self._client = client
-        self._logger = logger
-
-    async def resolve(self, message: ReplyTarget) -> tuple[MentionedUser, ...]:
-        text = message.raw_text or ""
-        surrogate_text = telegram_helpers.add_surrogate(text)
-        resolved: dict[int, MentionedUser] = {}
-        for entity in getattr(message, "entities", None) or ():
-            candidate: Any | None = None
-            if isinstance(entity, telegram_types.MessageEntityMentionName):
-                candidate = entity.user_id
-            elif isinstance(entity, telegram_types.MessageEntityMention):
-                mention = telegram_helpers.del_surrogate(
-                    surrogate_text[entity.offset : entity.offset + entity.length]
-                )
-                if not mention.startswith("@") or len(mention) < 2:
-                    continue
-                candidate = mention
-            else:
-                continue
-            try:
-                actor = await self._client.get_entity(candidate)
-            except Exception as exc:
-                if self._logger is not None:
-                    self._logger.debug(
-                        "Telegram mention lookup failed (%s): %s",
-                        type(exc).__name__,
-                        exc,
-                    )
-                continue
-            user_id = getattr(actor, "id", None)
-            if not isinstance(user_id, int) or user_id <= 0:
-                continue
-            resolved[user_id] = MentionedUser(
-                user_id=user_id,
-                display_name=_telegram_display_name(actor),
-            )
-        return tuple(resolved.values())
-
-
-class TelegramMemoryScopeTargetResolver:
-    def __init__(self, client: Any, *, logger: Any | None = None):
-        self._client = client
-        self._logger = logger
-
-    async def resolve(
-        self,
-        target: str,
-        *,
-        include_latest_message: bool = False,
-    ) -> MemoryScopeTarget:
-        digits = target.removeprefix("-")
-        if (
-            not digits
-            or not digits.isascii()
-            or not digits.isdecimal()
-            or int(target) == 0
-        ):
-            raise ValueError("Telegram target must be a non-zero numeric chat ID")
-        chat_id = int(target)
-        try:
-            entity = await self._client.get_entity(chat_id)
-            if not isinstance(
-                entity,
-                (telegram_types.Chat, telegram_types.Channel),
-            ):
-                raise ValueError("Telegram target is not a group or channel")
-            latest_message_id = 0
-            if include_latest_message:
-                messages = await self._client.get_messages(entity, limit=1)
-                if messages:
-                    latest_message_id = int(messages[0].id)
-        except Exception as exc:
-            if self._logger is not None:
-                self._logger.warning(
-                    "Telegram memory scope lookup failed "
-                    "(chat_id=%s, error=%s): %s",
-                    chat_id,
-                    type(exc).__name__,
-                    exc,
-                )
-            raise ValueError(
-                "Telegram group or channel is inaccessible"
-            ) from exc
-        return MemoryScopeTarget(
-            chat_id=telegram_utils.get_peer_id(entity),
-            display_name=_telegram_display_name(entity),
-            latest_message_id=latest_message_id,
-        )
 
 
 class ConversationStore(Protocol):
@@ -906,6 +763,8 @@ class PromptBuilder:
         history_source: MessageHistorySource | None = None,
         max_attachments: int = 3,
         transport: ChatTransport | None = None,
+        identity_codec: IdentityCodec | None = None,
+        metadata_resolver: Callable[[ReplyTarget], dict[str, Any]] | None = None,
     ):
         if max_context_messages < 1 or max_context_chars < 1:
             raise ValueError("Context limits must be positive")
@@ -920,6 +779,12 @@ class PromptBuilder:
         self.history_source = history_source
         self.max_attachments = max_attachments
         self._transport = transport or ObjectChatTransport()
+        self.identity_codec = identity_codec or NamespacedIdentityCodec(
+            source="chat",
+            actor_kind="actor",
+            scope_kind="scope",
+        )
+        self._metadata_resolver = metadata_resolver
 
     def has_attachment(self, message: ReplyTarget) -> bool:
         return (
@@ -956,6 +821,14 @@ class PromptBuilder:
             return await self.mention_resolver.resolve(message)
         except Exception:
             return ()
+
+    def resolve_metadata(self, message: ReplyTarget) -> dict[str, Any]:
+        if self._metadata_resolver is None:
+            return {}
+        try:
+            return self._metadata_resolver(message)
+        except Exception:
+            return {}
 
     async def load_chat_context(
         self,
@@ -1081,7 +954,7 @@ class PromptBuilder:
                         identity=message_identity,
                         reply_to_message_id=message.reply_to_msg_id,
                         mentioned_users=await self.resolve_mentions(message),
-                        metadata=_telegram_memory_event_metadata(message),
+                        metadata=self.resolve_metadata(message),
                     )
                 normalized.append(
                     ChatContextMessage(
@@ -1104,8 +977,8 @@ class PromptBuilder:
             current_reply_to_message_id=current_reply_to_message_id,
         )
 
-    @staticmethod
     def render_chat_context(
+        self,
         context: ChatContext,
         *,
         assistant_message_ids: frozenset[int] = frozenset(),
@@ -1151,7 +1024,7 @@ class PromptBuilder:
                     "actor_id="
                     + (
                         message.identity.subject_id
-                        or _telegram_subject_id(message.sender_id)
+                        or self.identity_codec.actor_id(message.sender_id)
                     )
                 )
             if message.identity.subject_display_name:
@@ -2246,6 +2119,7 @@ class AIConversationHandler:
         memory_scope_resolver: MemoryScopeTargetResolver | None = None,
         memory_command_delete_delay: float = 3.0,
         transport: ChatTransport | None = None,
+        identity_codec: IdentityCodec | None = None,
         logger: Any | None = None,
     ):
         if memory_command_delete_delay < 0:
@@ -2267,6 +2141,7 @@ class AIConversationHandler:
             or responder.transport
             or ObjectChatTransport()
         )
+        self._identity_codec = identity_codec or prompt_builder.identity_codec
 
     async def handle(self, message: ReplyTarget) -> bool:
         if message.sender_id is None or message.chat_id is None:
@@ -2531,7 +2406,9 @@ class AIConversationHandler:
                                 identity=current_identity,
                                 reply_to_message_id=message.reply_to_msg_id,
                                 mentioned_users=current_mentions,
-                                metadata=_telegram_memory_event_metadata(message),
+                                metadata=self._prompt_builder.resolve_metadata(
+                                    message
+                                ),
                             )
                         )
                     if retained_observations:
@@ -2666,7 +2543,7 @@ class AIConversationHandler:
                 latest_message_id=message.id,
             )
 
-        scope_id = _telegram_scope_id(target.chat_id)
+        scope_id = self._identity_codec.scope_id(target.chat_id)
         target_label = _memory_scope_target_label(target)
         destination = target_label if is_remote else "this chat"
         if command.mode == "continuous":
@@ -2713,7 +2590,7 @@ class AIConversationHandler:
 
     async def _handle_memory_scope_status(self, message: ReplyTarget) -> bool:
         assert message.chat_id is not None
-        scope_id = _telegram_scope_id(message.chat_id)
+        scope_id = self._identity_codec.scope_id(message.chat_id)
         scope = await self._store.get_memory_scope_state(scope_id)
         state = await self._store.get_memory_dream_state(scope_id)
         dream_status = "enabled" if scope.dream_enabled else "disabled"
@@ -2779,7 +2656,7 @@ class AIConversationHandler:
     async def _continuous_memory_enabled(self, chat_id: int) -> bool:
         try:
             state = await self._store.get_memory_scope_state(
-                _telegram_scope_id(chat_id)
+                self._identity_codec.scope_id(chat_id)
             )
             return state.continuous_enabled
         except Exception as exc:
@@ -2790,7 +2667,7 @@ class AIConversationHandler:
         assert message.chat_id is not None
         await self._schedule_memory_command_delete(message, "/ai_memory_dream")
         scope = await self._store.get_memory_scope_state(
-            _telegram_scope_id(message.chat_id)
+            self._identity_codec.scope_id(message.chat_id)
         )
         if scope.continuous_enabled:
             await self._reply_memory_excluded(
@@ -2964,22 +2841,24 @@ class AIConversationHandler:
         if self._memory is None:
             return None
         participants: dict[str, str | None] = {
-            _telegram_subject_id(requester_id): requester_identity.subject_display_name
+            self._identity_codec.actor_id(
+                requester_id
+            ): requester_identity.subject_display_name
         }
         for observation in observations:
             subject_id = (
                 observation.identity.subject_id
-                or _telegram_subject_id(observation.sender_id)
+                or self._identity_codec.actor_id(observation.sender_id)
             )
             display_name = observation.identity.subject_display_name
             if subject_id not in participants or display_name:
                 participants[subject_id] = display_name
             for mention in observation.mentioned_users:
-                subject_id = _telegram_subject_id(mention.user_id)
+                subject_id = self._identity_codec.actor_id(mention.user_id)
                 if subject_id not in participants or mention.display_name:
                     participants[subject_id] = mention.display_name
         for mention in current_mentions:
-            subject_id = _telegram_subject_id(mention.user_id)
+            subject_id = self._identity_codec.actor_id(mention.user_id)
             if subject_id not in participants or mention.display_name:
                 participants[subject_id] = mention.display_name
         anchors = tuple(
@@ -2992,7 +2871,7 @@ class AIConversationHandler:
             ]
         )
         return AgentMemoryTarget(
-            scope_id=_telegram_scope_id(chat_id),
+            scope_id=self._identity_codec.scope_id(chat_id),
             anchors=anchors,
         )
 
@@ -3065,7 +2944,8 @@ class AIConversationHandler:
                 ),
                 target_identity.subject_display_name,
             )
-            revision_episode = _telegram_revision_episode(
+            revision_episode = _chat_revision_episode(
+                self._identity_codec,
                 chat_id=message.chat_id,
                 command_message_id=message.id,
                 owner_id=self._owner_id,
@@ -3095,8 +2975,8 @@ class AIConversationHandler:
                 return True
             try:
                 await self._memory.revise(
-                    scope_id=_telegram_scope_id(message.chat_id),
-                    subject_id=_telegram_subject_id(target.sender_id),
+                    scope_id=self._identity_codec.scope_id(message.chat_id),
+                    subject_id=self._identity_codec.actor_id(target.sender_id),
                     instruction=instruction,
                 )
             except Exception as exc:
@@ -3147,8 +3027,8 @@ class AIConversationHandler:
         if self._memory is None or not observations:
             return None
         try:
-            scope_id = _telegram_scope_id(chat_id)
-            root_source_id = _telegram_memory_source_id(
+            scope_id = self._identity_codec.scope_id(chat_id)
+            root_source_id = self._identity_codec.message_source_id(
                 chat_id,
                 observations[0].message_id,
             )
@@ -3159,10 +3039,14 @@ class AIConversationHandler:
             append_to_dream_document = bool(
                 existing_document_id
                 and existing_document_id.startswith(
-                    ("telegram:dream-segment:", "telegram:dream-session:")
+                    (
+                        f"{self._identity_codec.source}:dream-segment:",
+                        f"{self._identity_codec.source}:dream-session:",
+                    )
                 )
             )
-            episode = _telegram_memory_episode(
+            episode = _chat_memory_episode(
+                self._identity_codec,
                 chat_id,
                 observations,
                 document_id=(
@@ -3297,71 +3181,6 @@ def _message_datetime(message: ReplyTarget) -> datetime:
     return value.astimezone(UTC)
 
 
-def _telegram_memory_event_metadata(message: ReplyTarget) -> dict[str, Any]:
-    metadata: dict[str, Any] = {}
-    chat_id = getattr(message, "chat_id", None)
-    post_author = getattr(message, "post_author", None)
-    if isinstance(post_author, str) and post_author.strip():
-        metadata["post_author"] = post_author.strip()[:256]
-    reply = getattr(message, "reply_to", None)
-    quote_text = getattr(reply, "quote_text", None)
-    if isinstance(quote_text, str) and quote_text.strip():
-        quotation: dict[str, Any] = {"text": quote_text.strip()[:4_000]}
-        reply_id = getattr(message, "reply_to_msg_id", None)
-        if isinstance(chat_id, int) and isinstance(reply_id, int):
-            quotation["source_id"] = _telegram_memory_source_id(chat_id, reply_id)
-        quote_offset = getattr(reply, "quote_offset", None)
-        if isinstance(quote_offset, int) and quote_offset >= 0:
-            quotation["offset"] = quote_offset
-        metadata["quotation"] = quotation
-
-    forward = getattr(message, "fwd_from", None)
-    if forward is not None:
-        attribution: dict[str, Any] = {}
-        from_name = getattr(forward, "from_name", None)
-        if isinstance(from_name, str) and from_name.strip():
-            attribution["actor_display_name"] = from_name.strip()[:256]
-        from_id = getattr(forward, "from_id", None)
-        if isinstance(from_id, telegram_types.PeerUser):
-            attribution["actor_id"] = _telegram_subject_id(from_id.user_id)
-        source_peer = getattr(forward, "saved_from_peer", None) or from_id
-        source_message_id = getattr(forward, "saved_from_msg_id", None) or getattr(
-            forward, "channel_post", None
-        )
-        if source_peer is not None and isinstance(source_message_id, int):
-            try:
-                source_chat_id = telegram_utils.get_peer_id(source_peer)
-            except (TypeError, ValueError):
-                source_chat_id = None
-            if isinstance(source_chat_id, int):
-                attribution["source_id"] = _telegram_memory_source_id(
-                    source_chat_id,
-                    source_message_id,
-                )
-        forwarded_at = getattr(forward, "date", None)
-        if isinstance(forwarded_at, datetime):
-            if forwarded_at.tzinfo is None:
-                forwarded_at = forwarded_at.replace(tzinfo=UTC)
-            attribution["source_time"] = (
-                forwarded_at.astimezone(UTC).isoformat().replace("+00:00", "Z")
-            )
-        if attribution:
-            metadata["forwarded_from"] = attribution
-    return metadata
-
-
-def _telegram_subject_id(user_id: int) -> str:
-    return f"telegram:user:{user_id}"
-
-
-def _telegram_channel_subject_id(channel_id: int) -> str:
-    return f"telegram:channel:{channel_id}"
-
-
-def _telegram_scope_id(chat_id: int) -> str:
-    return f"telegram:chat:{chat_id}"
-
-
 def _memory_scope_target_label(target: MemoryScopeTarget) -> str:
     if target.display_name:
         return f"{target.display_name} ({target.chat_id})"
@@ -3369,11 +3188,11 @@ def _memory_scope_target_label(target: MemoryScopeTarget) -> str:
 
 
 def _format_memory_scope_summary(state: MemoryScopeState) -> str:
-    chat_id = state.scope_id.removeprefix("telegram:chat:")
+    external_id = state.scope_id.rsplit(":", 1)[-1]
     label = (
-        f"{state.display_name} ({chat_id})"
+        f"{state.display_name} ({external_id})"
         if state.display_name
-        else chat_id
+        else state.scope_id
     )
     if state.continuous_enabled:
         cursor = (
@@ -3408,11 +3227,8 @@ def _format_memory_time(timestamp: float | None) -> str:
     )
 
 
-def _telegram_memory_source_id(chat_id: int, message_id: int) -> str:
-    return f"telegram:message:{chat_id}:{message_id}"
-
-
-def _telegram_memory_episode(
+def _chat_memory_episode(
+    identity_codec: IdentityCodec,
     chat_id: int,
     observations: tuple[HumanObservation, ...],
     *,
@@ -3431,26 +3247,29 @@ def _telegram_memory_episode(
         None,
     )
     return MemoryEpisode(
-        scope_id=_telegram_scope_id(chat_id),
+        scope_id=identity_codec.scope_id(chat_id),
         scope_display_name=scope_display_name,
-        document_id=(document_id or f"telegram:thread:{chat_id}:{root_message_id}"),
-        source="telegram",
+        document_id=(
+            document_id
+            or identity_codec.thread_document_id(chat_id, root_message_id)
+        ),
+        source=identity_codec.source,
         events=tuple(
             MemoryEvent(
-                source_id=_telegram_memory_source_id(
+                source_id=identity_codec.message_source_id(
                     chat_id,
                     observation.message_id,
                 ),
                 actor_id=(
                     observation.identity.subject_id
-                    or _telegram_subject_id(observation.sender_id)
+                    or identity_codec.actor_id(observation.sender_id)
                 ),
                 actor_display_name=observation.identity.subject_display_name,
                 occurred_at=observation.occurred_at,
                 text=observation.text,
                 mentioned_at=observation.mentioned_at,
                 reply_to_source_id=(
-                    _telegram_memory_source_id(
+                    identity_codec.message_source_id(
                         chat_id,
                         observation.reply_to_message_id,
                     )
@@ -3459,7 +3278,7 @@ def _telegram_memory_episode(
                 ),
                 mentioned_actors=tuple(
                     (
-                        _telegram_subject_id(mention.user_id),
+                        identity_codec.actor_id(mention.user_id),
                         mention.display_name,
                     )
                     for mention in observation.mentioned_users
@@ -3471,7 +3290,8 @@ def _telegram_memory_episode(
     )
 
 
-def _telegram_revision_episode(
+def _chat_revision_episode(
+    identity_codec: IdentityCodec,
     *,
     chat_id: int,
     command_message_id: int,
@@ -3483,27 +3303,30 @@ def _telegram_revision_episode(
     occurred_at: datetime,
     target_message_id: int,
 ) -> MemoryEpisode:
-    target_key = _telegram_subject_id(target_id)
+    target_key = identity_codec.actor_id(target_id)
     target_label = (
         f"{target_display_name} ({target_key})" if target_display_name else target_key
     )
     return MemoryEpisode(
-        scope_id=_telegram_scope_id(chat_id),
-        document_id=f"telegram:revision:{chat_id}:{command_message_id}",
-        source="telegram-revision",
+        scope_id=identity_codec.scope_id(chat_id),
+        document_id=identity_codec.revision_document_id(
+            chat_id,
+            command_message_id,
+        ),
+        source=f"{identity_codec.source}-revision",
         events=(
             MemoryEvent(
-                source_id=_telegram_memory_source_id(
+                source_id=identity_codec.message_source_id(
                     chat_id,
                     command_message_id,
                 ),
-                actor_id=_telegram_subject_id(owner_id),
+                actor_id=identity_codec.actor_id(owner_id),
                 actor_display_name=owner_display_name,
                 occurred_at=occurred_at,
                 text=(
                     f"Trusted owner memory revision about {target_label}: {instruction}"
                 ),
-                reply_to_source_id=_telegram_memory_source_id(
+                reply_to_source_id=identity_codec.message_source_id(
                     chat_id,
                     target_message_id,
                 ),
@@ -3530,22 +3353,6 @@ async def _record_episode_labels(
         episode.scope_display_name,
         actor_labels,
     )
-
-
-def _telegram_display_name(entity: Any | None) -> str | None:
-    if entity is None:
-        return None
-    display_name = telegram_utils.get_display_name(entity).strip()
-    if not display_name:
-        username = (getattr(entity, "username", None) or "").strip()
-        display_name = f"@{username}" if username else ""
-    display_name = " ".join(display_name.split())
-    return display_name[:256] or None
-
-
-def _memory_subject_label(user_id: int, display_name: str | None) -> str:
-    subject_id = _telegram_subject_id(user_id)
-    return f"{display_name} ({subject_id})" if display_name else subject_id
 
 
 def _pluralize(count: int, noun: str) -> str:

--- a/src/telefire/ai.py
+++ b/src/telefire/ai.py
@@ -5,7 +5,7 @@ import base64
 import json
 import os
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -16,9 +16,6 @@ import aiosqlite
 import aiohttp
 from telethon import helpers as telegram_helpers
 from telethon import utils as telegram_utils
-from telethon.errors import FloodWaitError, MessageNotModifiedError
-from telethon.extensions import html as telegram_html
-from telethon.tl import functions as telegram_functions
 from telethon.tl import types as telegram_types
 
 from telefire.ai_memory import (
@@ -34,47 +31,6 @@ from telefire.ai_attachments import (
 )
 from telefire.chat.attachments import AttachmentDescriber, AttachmentDescription
 from telefire.chat.transport import ChatTransport, ObjectChatTransport
-
-
-TelegramResponseFormat = Literal["regular_html", "rich_markdown"]
-TELEGRAM_REGULAR_HTML_FORMAT_GUIDE = """Response format: Telegram regular-message HTML.
-- Return only the answer. Do not wrap the whole response in a code block.
-- Use only these formatting tags: <b>bold</b>, <i>italic</i>, <u>underline</u>, <s>strikethrough</s>, <code>inline code</code>, <pre>preformatted block</pre>, <blockquote>quoted text</blockquote>, and <a href="https://example.com">link text</a>.
-- Use a short <b>bold heading</b> on its own line instead of Markdown headings. Use plain hyphen or numbered lines for lists.
-- Telegram regular messages have no native table entity. Render a compact table as aligned text inside <pre>; render a wide table as labeled list rows.
-- Escape literal <, >, and & as &lt;, &gt;, and &amp;. Close every tag. Do not nest formatting inside <code> or <pre>.
-- Do not emit Markdown markers such as **, __, # headings, > quotes, backticks, or pipe-table syntax."""
-TELEGRAM_RICH_MARKDOWN_FORMAT_GUIDE = """Response format: Telegram Bot API rich-message Markdown.
-- Return only the answer. Use GitHub-Flavored Markdown where possible.
-- Use **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, # headings, > blockquotes, lists, and links.
-- Native tables use this structure:
-| Header 1 | Header 2 |
-|:---------|:---------|
-| Value 1  | Value 2  |
-- Keep tables compact, close every formatting delimiter and code fence, and do not wrap the whole response in a code block."""
-
-
-def select_telegram_response_format(
-    *,
-    is_bot_account: bool,
-    rich_messages_available: bool,
-) -> TelegramResponseFormat:
-    if is_bot_account and rich_messages_available:
-        return "rich_markdown"
-    return "regular_html"
-
-
-def _telegram_system_prompt(
-    base_prompt: str,
-    response_format: TelegramResponseFormat = "regular_html",
-) -> str:
-    if response_format == "regular_html":
-        guide = TELEGRAM_REGULAR_HTML_FORMAT_GUIDE
-    elif response_format == "rich_markdown":
-        guide = TELEGRAM_RICH_MARKDOWN_FORMAT_GUIDE
-    else:
-        raise ValueError(f"Unsupported Telegram response format: {response_format}")
-    return f"{base_prompt.rstrip()}\n\n{guide}".lstrip()
 
 
 ToolPolicy = Literal["owner", "delegated", "none"]
@@ -711,66 +667,6 @@ class AnswerResult:
     entry_id: str | None = None
 
 
-class TelegramEditLimiter:
-    def __init__(
-        self,
-        minimum_interval: float,
-        *,
-        clock: Callable[[], float] = time.monotonic,
-        sleep: Callable[[float], Awaitable[None]] | None = None,
-        logger: Any | None = None,
-    ):
-        self._minimum_interval = max(0.0, minimum_interval)
-        self._clock = clock
-        self._sleep = sleep or asyncio.sleep
-        self._logger = logger
-        self._lock = asyncio.Lock()
-        self._next_edit_at = 0.0
-
-    async def run(
-        self,
-        operation: Callable[[], Awaitable[Any]],
-        *,
-        wait: bool,
-    ) -> bool:
-        if not wait and self._lock.locked():
-            return False
-
-        async with self._lock:
-            while True:
-                now = self._clock()
-                delay = self._next_edit_at - now
-                if delay > 0:
-                    if not wait:
-                        return False
-                    await self._sleep(delay)
-                    now = self._next_edit_at
-                    self._next_edit_at = 0.0
-
-                try:
-                    await operation()
-                except FloodWaitError as exc:
-                    seconds = max(0.0, float(exc.seconds))
-                    self._next_edit_at = now + seconds
-                    if self._logger is not None:
-                        self._logger.warning(
-                            "Telegram edit rate limited; waiting %.0f seconds",
-                            seconds,
-                        )
-                    if not wait:
-                        return False
-                    continue
-                except MessageNotModifiedError:
-                    self._next_edit_at = now + self._minimum_interval
-                    return True
-                except Exception:
-                    self._next_edit_at = now + self._minimum_interval
-                    raise
-
-                self._next_edit_at = now + self._minimum_interval
-                return True
-
-
 @dataclass(frozen=True, slots=True)
 class HumanObservation:
     message_id: int
@@ -915,36 +811,22 @@ class AIResponder:
         self,
         gateway: AgentGateway,
         *,
-        edit_cadence: float = 4.0,
         max_output_chars: int = 3_900,
-        response_format: TelegramResponseFormat = "regular_html",
-        clock: Callable[[], float] = time.monotonic,
-        edit_limiter: TelegramEditLimiter | None = None,
         transport: ChatTransport | None = None,
         logger: Any | None = None,
     ):
         self._gateway = gateway
-        self._transport = transport
-        self._response_format = response_format
-        self._edit_limiter = edit_limiter or TelegramEditLimiter(
-            edit_cadence,
-            clock=clock,
-            logger=logger,
-        )
+        self._transport = transport or ObjectChatTransport()
         self._max_output_chars = max(4, max_output_chars)
         self._logger = logger
 
     async def answer(
         self, trigger: ReplyTarget, request: AgentRunRequest
     ) -> AnswerResult:
-        answer = (
-            await self._transport.reply(
-                trigger,
-                "Thinking...",
-                presentation="plain",
-            )
-            if self._transport is not None
-            else await trigger.reply("Thinking...", parse_mode=None)
+        answer = await self._transport.reply(
+            trigger,
+            "Thinking...",
+            presentation="plain",
         )
         text = ""
         last_edited_source: str | None = None
@@ -961,7 +843,6 @@ class AIResponder:
                             answer,
                             event.summary,
                             wait=False,
-                            parse_mode=None,
                         )
                         if edited:
                             last_edited_source = None
@@ -980,7 +861,6 @@ class AIResponder:
                             answer,
                             cancelled,
                             wait=True,
-                            parse_mode=None,
                         )
                         return AnswerResult(
                             message=answer,
@@ -995,7 +875,6 @@ class AIResponder:
                             answer,
                             rate_limited,
                             wait=True,
-                            parse_mode=None,
                         )
                         return AnswerResult(
                             message=answer,
@@ -1018,7 +897,6 @@ class AIResponder:
                         answer,
                         final_text,
                         wait=True,
-                        parse_mode=None,
                     )
                     return AnswerResult(
                         message=answer,
@@ -1039,7 +917,6 @@ class AIResponder:
                 answer,
                 failure,
                 wait=True,
-                parse_mode=None,
             )
             return AnswerResult(message=answer, text=failure, succeeded=False)
 
@@ -1047,7 +924,7 @@ class AIResponder:
         return await self._gateway.cancel(run_id)
 
     @property
-    def transport(self) -> ChatTransport | None:
+    def transport(self) -> ChatTransport:
         return self._transport
 
     def _truncate(self, text: str) -> str:
@@ -1062,24 +939,11 @@ class AIResponder:
         *,
         wait: bool,
     ) -> bool:
-        if self._transport is not None:
-            return await self._transport.update(
-                answer,
-                text,
-                presentation="agent",
-                wait=wait,
-            )
-        if self._response_format == "rich_markdown":
-            return await self._edit_rich_markdown(answer, text, wait=wait)
-        rendered, entities = telegram_html.parse(text)
-        if not rendered.strip():
-            return False
-        return await self._edit_message(
+        return await self._transport.update(
             answer,
-            rendered,
+            text,
+            presentation="agent",
             wait=wait,
-            parse_mode=None,
-            formatting_entities=entities,
         )
 
     async def _edit_message(
@@ -1088,47 +952,13 @@ class AIResponder:
         text: str,
         *,
         wait: bool,
-        **kwargs: Any,
     ) -> bool:
-        if self._transport is not None:
-            return await self._transport.update(
-                answer,
-                text,
-                presentation="plain",
-                wait=wait,
-            )
-        return await self._edit_limiter.run(
-            lambda: answer.edit(text, **kwargs),
+        return await self._transport.update(
+            answer,
+            text,
+            presentation="plain",
             wait=wait,
         )
-
-    async def _edit_rich_markdown(
-        self,
-        answer: EditableMessage,
-        text: str,
-        *,
-        wait: bool,
-    ) -> bool:
-        if not text.strip().strip("*_~`#>|:-"):
-            return False
-        client = getattr(answer, "client", None)
-        get_input_chat = getattr(answer, "get_input_chat", None)
-        if client is None or not callable(get_input_chat):
-            raise RuntimeError("Telegram rich-message editing is unavailable")
-        peer = await get_input_chat()
-        if peer is None:
-            raise RuntimeError("Telegram rich-message peer is unavailable")
-
-        async def edit() -> None:
-            await client(
-                telegram_functions.messages.EditMessageRequest(
-                    peer=peer,
-                    id=answer.id,
-                    rich_message=telegram_types.InputRichMessageMarkdown(markdown=text),
-                )
-            )
-
-        return await self._edit_limiter.run(edit, wait=wait)
 
     def _log_failure(self, exc: Exception) -> None:
         if self._logger is not None:
@@ -1157,7 +987,6 @@ class PromptBuilder:
         system_prompt: str = AISettings.DEFAULT_SYSTEM_PROMPT,
         max_context_messages: int = 20,
         max_context_chars: int = 12_000,
-        response_format: TelegramResponseFormat = "regular_html",
         attachment_describer: AttachmentDescriber | None = None,
         identity_resolver: MessageIdentityResolver | None = None,
         mention_resolver: MessageMentionResolver | None = None,
@@ -1169,7 +998,7 @@ class PromptBuilder:
             raise ValueError("Context limits must be positive")
         if max_attachments < 0:
             raise ValueError("max_attachments cannot be negative")
-        self.system_prompt = _telegram_system_prompt(system_prompt, response_format)
+        self.system_prompt = system_prompt
         self.max_context_messages = max_context_messages
         self.max_context_chars = max_context_chars
         self.attachment_describer = attachment_describer

--- a/src/telefire/ai.py
+++ b/src/telefire/ai.py
@@ -31,11 +31,9 @@ from telefire.ai_memory import (
 )
 from telefire.ai_attachments import (
     AttachmentAnalysisRequest,
-    AttachmentDescriber,
-    AttachmentDescription,
-    message_has_attachment,
 )
-from telefire.chat.transport import ChatTransport
+from telefire.chat.attachments import AttachmentDescriber, AttachmentDescription
+from telefire.chat.transport import ChatTransport, ObjectChatTransport
 
 
 TelegramResponseFormat = Literal["regular_html", "rich_markdown"]
@@ -1048,6 +1046,10 @@ class AIResponder:
     async def cancel(self, run_id: str) -> bool:
         return await self._gateway.cancel(run_id)
 
+    @property
+    def transport(self) -> ChatTransport | None:
+        return self._transport
+
     def _truncate(self, text: str) -> str:
         if len(text) <= self._max_output_chars:
             return text
@@ -1161,6 +1163,7 @@ class PromptBuilder:
         mention_resolver: MessageMentionResolver | None = None,
         history_source: MessageHistorySource | None = None,
         max_attachments: int = 3,
+        transport: ChatTransport | None = None,
     ):
         if max_context_messages < 1 or max_context_chars < 1:
             raise ValueError("Context limits must be positive")
@@ -1174,12 +1177,19 @@ class PromptBuilder:
         self.mention_resolver = mention_resolver
         self.history_source = history_source
         self.max_attachments = max_attachments
+        self._transport = transport or ObjectChatTransport()
+
+    def has_attachment(self, message: ReplyTarget) -> bool:
+        return (
+            self.attachment_describer is not None
+            and self.attachment_describer.has_attachment(message)
+        )
 
     async def describe_attachment(
         self,
         message: ReplyTarget,
     ) -> AttachmentDescription | None:
-        if self.attachment_describer is None or not message_has_attachment(message):
+        if not self.has_attachment(message):
             return None
         try:
             return await self.attachment_describer.describe(message)
@@ -1211,7 +1221,9 @@ class PromptBuilder:
         *,
         recent_messages: int | None = None,
     ) -> ChatContext:
-        reply_path = await self._load_reply_path(await trigger.get_reply_message())
+        reply_path = await self._load_reply_path(
+            await self._transport.get_reply(trigger)
+        )
         recent: tuple[ReplyTarget, ...] = ()
         if recent_messages is not None:
             if not 1 <= recent_messages <= self.max_context_messages:
@@ -1260,7 +1272,7 @@ class PromptBuilder:
                 break
             seen.add(key)
             newest_first.append(current)
-            current = await current.get_reply_message()
+            current = await self._transport.get_reply(current)
         return tuple(newest_first)
 
     async def _build_chat_context(
@@ -2491,6 +2503,7 @@ class AIConversationHandler:
         dream_runner: MemoryDreamRunner | None = None,
         memory_scope_resolver: MemoryScopeTargetResolver | None = None,
         memory_command_delete_delay: float = 3.0,
+        transport: ChatTransport | None = None,
         logger: Any | None = None,
     ):
         if memory_command_delete_delay < 0:
@@ -2507,14 +2520,20 @@ class AIConversationHandler:
         self._memory_command_delete_tasks: set[asyncio.Task[None]] = set()
         self._logger = logger
         self._active_runs: dict[int, str] = {}
+        self._transport = (
+            transport
+            or responder.transport
+            or ObjectChatTransport()
+        )
 
     async def handle(self, message: ReplyTarget) -> bool:
         if message.sender_id is None or message.chat_id is None:
             return False
         command = (message.raw_text or "").strip()
         command_name = command.split(maxsplit=1)[0] if command else ""
-        is_owner_control = message.sender_id == self._owner_id or bool(
-            getattr(message, "out", False)
+        is_owner_control = (
+            message.sender_id == self._owner_id
+            or self._transport.is_outgoing(message)
         )
         memory_instruction = parse_memory_revision(message.raw_text)
         if memory_instruction is not None:
@@ -2612,7 +2631,7 @@ class AIConversationHandler:
         reference_context = ""
         anchor_observations: list[HumanObservation] = []
         retained_observations: list[HumanObservation] = []
-        has_current_attachment = message_has_attachment(message)
+        has_current_attachment = self._prompt_builder.has_attachment(message)
         authored_prompt = ""
         if ai_trigger is not None:
             if not ai_trigger.prompt and not has_current_attachment:
@@ -2813,7 +2832,7 @@ class AIConversationHandler:
         message: ReplyTarget,
     ) -> AIAnswerMarker | None:
         assert message.chat_id is not None
-        current = await message.get_reply_message()
+        current = await self._transport.get_reply(message)
         seen: set[tuple[int | None, int]] = set()
         for _ in range(self._prompt_builder.max_context_messages):
             if current is None:
@@ -2825,7 +2844,7 @@ class AIConversationHandler:
             turn = await self._store.get_turn_for_message(message.chat_id, current.id)
             if turn is not None:
                 return turn
-            current = await current.get_reply_message()
+            current = await self._transport.get_reply(current)
         return None
 
     async def _handle_cancel(self, message: ReplyTarget) -> bool:
@@ -2852,7 +2871,7 @@ class AIConversationHandler:
         message: ReplyTarget,
         command: str,
     ) -> bool:
-        target = await message.get_reply_message()
+        target = await self._transport.get_reply(message)
         if target is None or target.sender_id is None:
             await self._reply_memory_excluded(
                 message,
@@ -3107,19 +3126,23 @@ class AIConversationHandler:
             result = await self._dream_runner.run_backfill(message.chat_id, request)
         except Exception as exc:
             self._log_memory_failure("backfill", exc)
-            await progress.edit(
+            await self._transport.update(
+                progress,
                 "Memory backfill failed. Accepted documents are safe; "
                 "retry the same command.",
-                parse_mode=None,
+                presentation="plain",
+                wait=True,
             )
             return True
-        await progress.edit(
+        await self._transport.update(
+            progress,
             "Memory backfill complete: "
             f"scanned {_pluralize(result.messages_seen, 'message')}; "
             f"retained {result.messages_retained} in "
             f"{_pluralize(result.documents_created, 'updated thread')}; "
             f"{result.documents_unchanged} unchanged.",
-            parse_mode=None,
+            presentation="plain",
+            wait=True,
         )
         return True
 
@@ -3130,7 +3153,11 @@ class AIConversationHandler:
         *,
         kind: str,
     ) -> EditableMessage:
-        reply = await message.reply(text, parse_mode=None)
+        reply = await self._transport.reply(
+            message,
+            text,
+            presentation="plain",
+        )
         if message.chat_id is not None:
             await self._mark_memory_excluded(message.chat_id, reply.id, kind)
         return reply
@@ -3247,7 +3274,7 @@ class AIConversationHandler:
                 kind="memory-control",
             )
             return True
-        target = await message.get_reply_message()
+        target = await self._transport.get_reply(message)
         if target is None or target.sender_id is None:
             await self._reply_memory_excluded(
                 message,
@@ -3435,11 +3462,8 @@ class AIConversationHandler:
         message: ReplyTarget,
         command: str,
     ) -> None:
-        delete = getattr(message, "delete", None)
-        if not callable(delete):
-            return
         try:
-            await delete()
+            await self._transport.delete(message)
         except Exception as exc:
             if self._logger is not None:
                 self._logger.warning(

--- a/src/telefire/ai.py
+++ b/src/telefire/ai.py
@@ -41,7 +41,7 @@ from telefire.chat.commands import (
     parse_chat_command,
 )
 from telefire.chat.identity import IdentityCodec, NamespacedIdentityCodec
-from telefire.chat.transport import ChatTransport, ObjectChatTransport
+from telefire.chat.transport import ChatTransport, ObjectChatTransport, SentMessage
 
 
 ToolPolicy = Literal["owner", "delegated", "none"]
@@ -236,13 +236,6 @@ class PiAgentGateway:
         return self._session
 
 
-class EditableMessage(Protocol):
-    id: int
-    text: str | None
-
-    async def edit(self, text: str, **kwargs: Any) -> Any: ...
-
-
 class ReplyTarget(Protocol):
     id: int
     chat_id: int | None
@@ -250,10 +243,6 @@ class ReplyTarget(Protocol):
     sender_id: int | None
     reply_to_msg_id: int | None
     date: datetime | None
-
-    async def reply(self, text: str, **kwargs: Any) -> EditableMessage: ...
-
-    async def get_reply_message(self) -> ReplyTarget | None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -309,24 +298,28 @@ class MessageHistorySource(Protocol):
 
 class ConversationStore(Protocol):
     async def get_answer(
-        self, chat_id: int, answer_message_id: int
+        self, scope_id: str, answer_message_id: int
     ) -> AIAnswerMarker | None: ...
 
     async def get_turn_for_message(
-        self, chat_id: int, message_id: int
+        self, scope_id: str, message_id: int
     ) -> AIAnswerMarker | None: ...
 
     async def save_answer(self, marker: AIAnswerMarker) -> None: ...
 
-    async def is_allowed(self, user_id: int) -> bool: ...
+    async def is_allowed(self, actor_id: str) -> bool: ...
 
-    async def allow_user(self, user_id: int) -> None: ...
+    async def allow_user(self, actor_id: str) -> None: ...
 
-    async def deny_user(self, user_id: int) -> None: ...
+    async def deny_user(self, actor_id: str) -> None: ...
 
-    async def get_last_request_at(self, user_id: int) -> float | None: ...
+    async def get_last_request_at(self, actor_id: str) -> float | None: ...
 
-    async def set_last_request_at(self, user_id: int, timestamp: float) -> None: ...
+    async def set_last_request_at(
+        self,
+        actor_id: str,
+        timestamp: float,
+    ) -> None: ...
 
     async def get_memory_document_receipt(
         self,
@@ -381,14 +374,14 @@ class ConversationStore(Protocol):
 
     async def mark_memory_excluded_message(
         self,
-        chat_id: int,
+        scope_id: str,
         message_id: int,
         kind: str,
     ) -> None: ...
 
     async def is_memory_excluded_message(
         self,
-        chat_id: int,
+        scope_id: str,
         message_id: int,
     ) -> bool: ...
 
@@ -508,10 +501,10 @@ class AISettings:
 
 @dataclass(frozen=True, slots=True)
 class AIAnswerMarker:
-    chat_id: int
+    scope_id: str
     answer_message_id: int
     trigger_message_id: int
-    requester_id: int
+    requester_id: str
     prompt: str
     answer_text: str
     parent_answer_message_id: int | None
@@ -522,7 +515,7 @@ class AIAnswerMarker:
 
 @dataclass(frozen=True, slots=True)
 class AnswerResult:
-    message: EditableMessage
+    message: SentMessage
     text: str
     succeeded: bool
     session_id: str | None = None
@@ -704,7 +697,7 @@ class AIResponder:
 
     async def _edit_formatted(
         self,
-        answer: EditableMessage,
+        answer: SentMessage,
         text: str,
         *,
         wait: bool,
@@ -718,7 +711,7 @@ class AIResponder:
 
     async def _edit_message(
         self,
-        answer: EditableMessage,
+        answer: SentMessage,
         text: str,
         *,
         wait: bool,
@@ -1092,29 +1085,7 @@ class AIStateRepository:
         self._connection = await aiosqlite.connect(self.path)
         self._connection.row_factory = aiosqlite.Row
         await self._connection.execute("PRAGMA journal_mode=WAL")
-        await self._connection.execute(
-            """
-            CREATE TABLE IF NOT EXISTS ai_answers (
-                chat_id INTEGER NOT NULL,
-                answer_message_id INTEGER NOT NULL,
-                trigger_message_id INTEGER NOT NULL,
-                requester_id INTEGER NOT NULL,
-                prompt TEXT NOT NULL,
-                answer_text TEXT NOT NULL,
-                parent_answer_message_id INTEGER,
-                reference_context TEXT NOT NULL,
-                agent_session_id TEXT,
-                agent_entry_id TEXT,
-                PRIMARY KEY (chat_id, answer_message_id)
-            )
-            """
-        )
-        await self._connection.execute(
-            """
-            CREATE INDEX IF NOT EXISTS ai_answers_by_trigger
-            ON ai_answers (chat_id, trigger_message_id, answer_message_id DESC)
-            """
-        )
+        await self._ensure_conversation_state_schema()
         await self._connection.execute(
             """
             CREATE TABLE IF NOT EXISTS ai_memory_scope_labels (
@@ -1132,47 +1103,6 @@ class AIStateRepository:
                 display_name TEXT NOT NULL,
                 updated_at REAL NOT NULL,
                 PRIMARY KEY (scope_id, actor_id)
-            )
-            """
-        )
-        await self._connection.execute(
-            """
-            CREATE TABLE IF NOT EXISTS ai_memory_excluded_messages (
-                chat_id INTEGER NOT NULL,
-                message_id INTEGER NOT NULL,
-                kind TEXT NOT NULL,
-                created_at REAL NOT NULL,
-                PRIMARY KEY (chat_id, message_id)
-            )
-            """
-        )
-        columns = {
-            row["name"]
-            async for row in await self._connection.execute(
-                "PRAGMA table_info(ai_answers)"
-            )
-        }
-        if "agent_session_id" not in columns:
-            await self._connection.execute(
-                "ALTER TABLE ai_answers ADD COLUMN agent_session_id TEXT"
-            )
-        if "agent_entry_id" not in columns:
-            await self._connection.execute(
-                "ALTER TABLE ai_answers ADD COLUMN agent_entry_id TEXT"
-            )
-        await self._connection.execute(
-            """
-            CREATE TABLE IF NOT EXISTS ai_whitelist (
-                user_id INTEGER PRIMARY KEY,
-                allowed_at REAL NOT NULL
-            )
-            """
-        )
-        await self._connection.execute(
-            """
-            CREATE TABLE IF NOT EXISTS ai_usage (
-                user_id INTEGER PRIMARY KEY,
-                last_request_at REAL NOT NULL
             )
             """
         )
@@ -1253,6 +1183,202 @@ class AIStateRepository:
             await self._connection.close()
             self._connection = None
 
+    async def _ensure_conversation_state_schema(self) -> None:
+        # State written before identity namespacing could only come from Telegram.
+        # Rebuild those tables once; all runtime reads and writes use opaque IDs.
+        await self._ensure_ai_answers_schema()
+        await self._ensure_actor_state_table(
+            "ai_whitelist",
+            value_definition="allowed_at REAL NOT NULL",
+        )
+        await self._ensure_actor_state_table(
+            "ai_usage",
+            value_definition="last_request_at REAL NOT NULL",
+        )
+        await self._ensure_excluded_messages_schema()
+
+    async def _ensure_ai_answers_schema(self) -> None:
+        connection = self._require_connection()
+        columns = await self._table_columns("ai_answers")
+        if not columns:
+            await self._create_ai_answers_table()
+            return
+        if "scope_id" in columns:
+            if "agent_session_id" not in columns:
+                await connection.execute(
+                    "ALTER TABLE ai_answers ADD COLUMN agent_session_id TEXT"
+                )
+            if "agent_entry_id" not in columns:
+                await connection.execute(
+                    "ALTER TABLE ai_answers ADD COLUMN agent_entry_id TEXT"
+                )
+            await self._create_ai_answers_index()
+            return
+
+        session_value = (
+            "agent_session_id" if "agent_session_id" in columns else "NULL"
+        )
+        entry_value = "agent_entry_id" if "agent_entry_id" in columns else "NULL"
+        await connection.execute("DROP INDEX IF EXISTS ai_answers_by_trigger")
+        await connection.execute(
+            "ALTER TABLE ai_answers RENAME TO ai_answers_legacy"
+        )
+        await self._create_ai_answers_table()
+        await connection.execute(
+            f"""
+            INSERT INTO ai_answers (
+                scope_id, answer_message_id, trigger_message_id, requester_id,
+                prompt, answer_text, parent_answer_message_id, reference_context,
+                agent_session_id, agent_entry_id
+            )
+            SELECT
+                'telegram:chat:' || chat_id,
+                answer_message_id,
+                trigger_message_id,
+                'telegram:user:' || requester_id,
+                prompt,
+                answer_text,
+                parent_answer_message_id,
+                reference_context,
+                {session_value},
+                {entry_value}
+            FROM ai_answers_legacy
+            """  # nosec B608
+        )
+        await connection.execute("DROP TABLE ai_answers_legacy")
+
+    async def _create_ai_answers_table(self) -> None:
+        connection = self._require_connection()
+        await connection.execute(
+            """
+            CREATE TABLE ai_answers (
+                scope_id TEXT NOT NULL,
+                answer_message_id INTEGER NOT NULL,
+                trigger_message_id INTEGER NOT NULL,
+                requester_id TEXT NOT NULL,
+                prompt TEXT NOT NULL,
+                answer_text TEXT NOT NULL,
+                parent_answer_message_id INTEGER,
+                reference_context TEXT NOT NULL,
+                agent_session_id TEXT,
+                agent_entry_id TEXT,
+                PRIMARY KEY (scope_id, answer_message_id)
+            )
+            """
+        )
+        await self._create_ai_answers_index()
+
+    async def _create_ai_answers_index(self) -> None:
+        await self._require_connection().execute(
+            """
+            CREATE INDEX IF NOT EXISTS ai_answers_by_trigger
+            ON ai_answers (
+                scope_id,
+                trigger_message_id,
+                answer_message_id DESC
+            )
+            """
+        )
+
+    async def _ensure_actor_state_table(
+        self,
+        table: str,
+        *,
+        value_definition: str,
+    ) -> None:
+        connection = self._require_connection()
+        columns = await self._table_columns(table)
+        value_column = value_definition.split(maxsplit=1)[0]
+        if not columns:
+            await connection.execute(
+                f"""
+                CREATE TABLE {table} (
+                    actor_id TEXT PRIMARY KEY,
+                    {value_definition}
+                )
+                """  # nosec B608
+            )
+            return
+        if "actor_id" in columns:
+            return
+
+        legacy = f"{table}_legacy"
+        await connection.execute(f"ALTER TABLE {table} RENAME TO {legacy}")  # nosec B608
+        await connection.execute(
+            f"""
+            CREATE TABLE {table} (
+                actor_id TEXT PRIMARY KEY,
+                {value_definition}
+            )
+            """  # nosec B608
+        )
+        await connection.execute(
+            f"""
+            INSERT INTO {table} (actor_id, {value_column})
+            SELECT 'telegram:user:' || user_id, {value_column}
+            FROM {legacy}
+            """  # nosec B608
+        )
+        await connection.execute(f"DROP TABLE {legacy}")  # nosec B608
+
+    async def _ensure_excluded_messages_schema(self) -> None:
+        connection = self._require_connection()
+        columns = await self._table_columns("ai_memory_excluded_messages")
+        if not columns:
+            await self._create_excluded_messages_table()
+            return
+        if "scope_id" in columns:
+            return
+        await connection.execute(
+            "ALTER TABLE ai_memory_excluded_messages "
+            "RENAME TO ai_memory_excluded_messages_legacy"
+        )
+        await self._create_excluded_messages_table()
+        await connection.execute(
+            """
+            INSERT INTO ai_memory_excluded_messages (
+                scope_id, message_id, kind, created_at
+            )
+            SELECT
+                'telegram:chat:' || chat_id,
+                message_id,
+                kind,
+                created_at
+            FROM ai_memory_excluded_messages_legacy
+            """
+        )
+        await connection.execute(
+            "DROP TABLE ai_memory_excluded_messages_legacy"
+        )
+
+    async def _create_excluded_messages_table(self) -> None:
+        await self._require_connection().execute(
+            """
+            CREATE TABLE ai_memory_excluded_messages (
+                scope_id TEXT NOT NULL,
+                message_id INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                PRIMARY KEY (scope_id, message_id)
+            )
+            """
+        )
+
+    async def _table_columns(self, table: str) -> set[str]:
+        connection = self._require_connection()
+        cursor = await connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table,),
+        )
+        if await cursor.fetchone() is None:
+            return set()
+        return {
+            str(row["name"])
+            async for row in await connection.execute(
+                f"PRAGMA table_info({table})"  # nosec B608
+            )
+        }
+
     async def _ensure_memory_scope_schema(self) -> None:
         connection = self._require_connection()
         cursor = await connection.execute(
@@ -1306,29 +1432,29 @@ class AIStateRepository:
         )
 
     async def get_answer(
-        self, chat_id: int, answer_message_id: int
+        self, scope_id: str, answer_message_id: int
     ) -> AIAnswerMarker | None:
         connection = self._require_connection()
         cursor = await connection.execute(
-            "SELECT * FROM ai_answers WHERE chat_id = ? AND answer_message_id = ?",
-            (chat_id, answer_message_id),
+            "SELECT * FROM ai_answers WHERE scope_id = ? AND answer_message_id = ?",
+            (scope_id, answer_message_id),
         )
         row = await cursor.fetchone()
         return _marker_from_row(row) if row else None
 
     async def get_turn_for_message(
-        self, chat_id: int, message_id: int
+        self, scope_id: str, message_id: int
     ) -> AIAnswerMarker | None:
         connection = self._require_connection()
         cursor = await connection.execute(
             """
             SELECT * FROM ai_answers
-            WHERE chat_id = ?
+            WHERE scope_id = ?
               AND (answer_message_id = ? OR trigger_message_id = ?)
             ORDER BY answer_message_id = ? DESC, answer_message_id DESC
             LIMIT 1
             """,
-            (chat_id, message_id, message_id, message_id),
+            (scope_id, message_id, message_id, message_id),
         )
         row = await cursor.fetchone()
         return _marker_from_row(row) if row else None
@@ -1338,11 +1464,11 @@ class AIStateRepository:
         await connection.execute(
             """
             INSERT INTO ai_answers (
-                chat_id, answer_message_id, trigger_message_id, requester_id,
+                scope_id, answer_message_id, trigger_message_id, requester_id,
                 prompt, answer_text, parent_answer_message_id, reference_context,
                 agent_session_id, agent_entry_id
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(chat_id, answer_message_id) DO UPDATE SET
+            ON CONFLICT(scope_id, answer_message_id) DO UPDATE SET
                 trigger_message_id = excluded.trigger_message_id,
                 requester_id = excluded.requester_id,
                 prompt = excluded.prompt,
@@ -1353,7 +1479,7 @@ class AIStateRepository:
                 agent_entry_id = excluded.agent_entry_id
             """,
             (
-                marker.chat_id,
+                marker.scope_id,
                 marker.answer_message_id,
                 marker.trigger_message_id,
                 marker.requester_id,
@@ -1367,47 +1493,50 @@ class AIStateRepository:
         )
         await connection.commit()
 
-    async def is_allowed(self, user_id: int) -> bool:
+    async def is_allowed(self, actor_id: str) -> bool:
         connection = self._require_connection()
         cursor = await connection.execute(
-            "SELECT 1 FROM ai_whitelist WHERE user_id = ?",
-            (user_id,),
+            "SELECT 1 FROM ai_whitelist WHERE actor_id = ?",
+            (actor_id,),
         )
         return await cursor.fetchone() is not None
 
-    async def allow_user(self, user_id: int) -> None:
+    async def allow_user(self, actor_id: str) -> None:
         connection = self._require_connection()
         await connection.execute(
-            "INSERT INTO ai_whitelist (user_id, allowed_at) VALUES (?, ?) "
-            "ON CONFLICT(user_id) DO UPDATE SET allowed_at = excluded.allowed_at",
-            (user_id, time.time()),
+            "INSERT INTO ai_whitelist (actor_id, allowed_at) VALUES (?, ?) "
+            "ON CONFLICT(actor_id) DO UPDATE SET allowed_at = excluded.allowed_at",
+            (actor_id, time.time()),
         )
         await connection.commit()
 
-    async def deny_user(self, user_id: int) -> None:
+    async def deny_user(self, actor_id: str) -> None:
         connection = self._require_connection()
         await connection.execute(
-            "DELETE FROM ai_whitelist WHERE user_id = ?", (user_id,)
+            "DELETE FROM ai_whitelist WHERE actor_id = ?", (actor_id,)
         )
-        await connection.execute("DELETE FROM ai_usage WHERE user_id = ?", (user_id,))
+        await connection.execute(
+            "DELETE FROM ai_usage WHERE actor_id = ?",
+            (actor_id,),
+        )
         await connection.commit()
 
-    async def get_last_request_at(self, user_id: int) -> float | None:
+    async def get_last_request_at(self, actor_id: str) -> float | None:
         connection = self._require_connection()
         cursor = await connection.execute(
-            "SELECT last_request_at FROM ai_usage WHERE user_id = ?",
-            (user_id,),
+            "SELECT last_request_at FROM ai_usage WHERE actor_id = ?",
+            (actor_id,),
         )
         row = await cursor.fetchone()
         return float(row["last_request_at"]) if row else None
 
-    async def set_last_request_at(self, user_id: int, timestamp: float) -> None:
+    async def set_last_request_at(self, actor_id: str, timestamp: float) -> None:
         connection = self._require_connection()
         await connection.execute(
-            "INSERT INTO ai_usage (user_id, last_request_at) VALUES (?, ?) "
-            "ON CONFLICT(user_id) DO UPDATE SET "
+            "INSERT INTO ai_usage (actor_id, last_request_at) VALUES (?, ?) "
+            "ON CONFLICT(actor_id) DO UPDATE SET "
             "last_request_at = excluded.last_request_at",
-            (user_id, timestamp),
+            (actor_id, timestamp),
         )
         await connection.commit()
 
@@ -1991,7 +2120,7 @@ class AIStateRepository:
 
     async def mark_memory_excluded_message(
         self,
-        chat_id: int,
+        scope_id: str,
         message_id: int,
         kind: str,
     ) -> None:
@@ -1999,29 +2128,29 @@ class AIStateRepository:
         await connection.execute(
             """
             INSERT OR REPLACE INTO ai_memory_excluded_messages (
-                chat_id, message_id, kind, created_at
+                scope_id, message_id, kind, created_at
             ) VALUES (?, ?, ?, ?)
             """,
-            (chat_id, message_id, kind, time.time()),
+            (scope_id, message_id, kind, time.time()),
         )
         await connection.commit()
 
     async def is_memory_excluded_message(
         self,
-        chat_id: int,
+        scope_id: str,
         message_id: int,
     ) -> bool:
         connection = self._require_connection()
         cursor = await connection.execute(
             "SELECT 1 FROM ai_memory_excluded_messages "
-            "WHERE chat_id = ? AND message_id = ?",
-            (chat_id, message_id),
+            "WHERE scope_id = ? AND message_id = ?",
+            (scope_id, message_id),
         )
         return await cursor.fetchone() is not None
 
     async def get_memory_excluded_message_ids(
         self,
-        chat_id: int,
+        scope_id: str,
         message_ids: tuple[int, ...],
     ) -> frozenset[int]:
         connection = self._require_connection()
@@ -2032,8 +2161,8 @@ class AIStateRepository:
             placeholders = ",".join("?" for _ in batch)
             cursor = await connection.execute(
                 "SELECT message_id FROM ai_memory_excluded_messages "  # nosec B608
-                f"WHERE chat_id = ? AND message_id IN ({placeholders})",
-                (chat_id, *batch),
+                f"WHERE scope_id = ? AND message_id IN ({placeholders})",
+                (scope_id, *batch),
             )
             async for row in cursor:
                 excluded.add(int(row["message_id"]))
@@ -2041,7 +2170,7 @@ class AIStateRepository:
 
     async def get_ai_answer_message_ids(
         self,
-        chat_id: int,
+        scope_id: str,
         message_ids: tuple[int, ...],
     ) -> frozenset[int]:
         connection = self._require_connection()
@@ -2052,8 +2181,8 @@ class AIStateRepository:
             placeholders = ",".join("?" for _ in batch)
             cursor = await connection.execute(
                 "SELECT answer_message_id FROM ai_answers "  # nosec B608
-                f"WHERE chat_id = ? AND answer_message_id IN ({placeholders})",
-                (chat_id, *batch),
+                f"WHERE scope_id = ? AND answer_message_id IN ({placeholders})",
+                (scope_id, *batch),
             )
             async for row in cursor:
                 answers.add(int(row["answer_message_id"]))
@@ -2078,32 +2207,32 @@ class AIRateLimiter:
         self._store = store
         self._cooldown_seconds = cooldown_seconds
         self._clock = clock
-        self._in_flight: set[int] = set()
+        self._in_flight: set[str] = set()
         self._lock = asyncio.Lock()
 
-    async def acquire(self, *, user_id: int, is_owner: bool) -> bool:
+    async def acquire(self, *, actor_id: str, is_owner: bool) -> bool:
         if is_owner:
             return True
         async with self._lock:
-            if user_id in self._in_flight:
+            if actor_id in self._in_flight:
                 return False
-            last_request_at = await self._store.get_last_request_at(user_id)
+            last_request_at = await self._store.get_last_request_at(actor_id)
             if (
                 last_request_at is not None
                 and self._clock() - last_request_at < self._cooldown_seconds
             ):
                 return False
-            self._in_flight.add(user_id)
+            self._in_flight.add(actor_id)
             return True
 
-    async def release(self, *, user_id: int, is_owner: bool) -> None:
+    async def release(self, *, actor_id: str, is_owner: bool) -> None:
         if is_owner:
             return
         async with self._lock:
             try:
-                await self._store.set_last_request_at(user_id, self._clock())
+                await self._store.set_last_request_at(actor_id, self._clock())
             finally:
-                self._in_flight.discard(user_id)
+                self._in_flight.discard(actor_id)
 
 
 class AIConversationHandler:
@@ -2135,21 +2264,24 @@ class AIConversationHandler:
         self._memory_command_delete_delay = memory_command_delete_delay
         self._memory_command_delete_tasks: set[asyncio.Task[None]] = set()
         self._logger = logger
-        self._active_runs: dict[int, str] = {}
         self._transport = (
             transport
             or responder.transport
             or ObjectChatTransport()
         )
         self._identity_codec = identity_codec or prompt_builder.identity_codec
+        self._owner_actor_id = self._identity_codec.actor_id(owner_id)
+        self._active_runs: dict[str, str] = {}
 
     async def handle(self, message: ReplyTarget) -> bool:
         if message.sender_id is None or message.chat_id is None:
             return False
+        actor_id = self._identity_codec.actor_id(message.sender_id)
+        scope_id = self._identity_codec.scope_id(message.chat_id)
         command = parse_chat_command(message.raw_text)
+        is_owner = actor_id == self._owner_actor_id
         is_owner_control = (
-            message.sender_id == self._owner_id
-            or self._transport.is_outgoing(message)
+            is_owner or self._transport.is_outgoing(message)
         )
         if isinstance(command, MemoryRememberCommand):
             if not is_owner_control:
@@ -2200,11 +2332,10 @@ class AIConversationHandler:
                 return False
             return await self._handle_access_command(message, command)
 
-        is_owner = message.sender_id == self._owner_id
         if isinstance(command, AICancelCommand):
-            if not is_owner and not await self._store.is_allowed(message.sender_id):
+            if not is_owner and not await self._store.is_allowed(actor_id):
                 return False
-            return await self._handle_cancel(message)
+            return await self._handle_cancel(message, actor_id)
 
         ai_trigger = command if isinstance(command, AIAskCommand) else None
         if command is not None and ai_trigger is None:
@@ -2212,7 +2343,7 @@ class AIConversationHandler:
         if ai_trigger is None and message.reply_to_msg_id is None:
             return False
 
-        if not is_owner and not await self._store.is_allowed(message.sender_id):
+        if not is_owner and not await self._store.is_allowed(actor_id):
             return False
         if (
             ai_trigger is not None
@@ -2257,7 +2388,7 @@ class AIConversationHandler:
             parent_answer_id = message.reply_to_msg_id
             if parent_answer_id is None:
                 return False
-            parent = await self._store.get_answer(message.chat_id, parent_answer_id)
+            parent = await self._store.get_answer(scope_id, parent_answer_id)
             if parent is None:
                 return False
             if not parent.agent_session_id or not parent.agent_entry_id:
@@ -2275,7 +2406,7 @@ class AIConversationHandler:
             prompt = authored_prompt or "Describe the attached content."
 
         acquired = await self._rate_limiter.acquire(
-            user_id=message.sender_id,
+            actor_id=actor_id,
             is_owner=is_owner,
         )
         if not acquired:
@@ -2324,7 +2455,7 @@ class AIConversationHandler:
                     human_context,
                     human_reply_path,
                 ) = await self._classify_chat_context(
-                    message.chat_id,
+                    scope_id,
                     loaded_context,
                 )
                 if ai_trigger is not None:
@@ -2359,24 +2490,24 @@ class AIConversationHandler:
                 tool_policy="owner" if is_owner else "delegated",
                 memory=memory_target,
             )
-            self._active_runs[message.sender_id] = run_id
+            self._active_runs[actor_id] = run_id
             result = await self._responder.answer(message, request)
             await self._mark_memory_excluded(
-                message.chat_id,
+                scope_id,
                 result.message.id,
                 "ai-answer",
             )
-            if self._active_runs.get(message.sender_id) == run_id:
-                self._active_runs.pop(message.sender_id, None)
+            if self._active_runs.get(actor_id) == run_id:
+                self._active_runs.pop(actor_id, None)
             if result.succeeded:
                 assert result.session_id is not None
                 assert result.entry_id is not None
                 await self._store.save_answer(
                     AIAnswerMarker(
-                        chat_id=message.chat_id,
+                        scope_id=scope_id,
                         answer_message_id=result.message.id,
                         trigger_message_id=message.id,
-                        requester_id=message.sender_id,
+                        requester_id=actor_id,
                         prompt=prompt,
                         answer_text=result.text,
                         parent_answer_message_id=parent_answer_id,
@@ -2386,7 +2517,7 @@ class AIConversationHandler:
                     )
                 )
                 await self._rate_limiter.release(
-                    user_id=message.sender_id,
+                    actor_id=actor_id,
                     is_owner=is_owner,
                 )
                 rate_released = True
@@ -2421,12 +2552,12 @@ class AIConversationHandler:
             if (
                 message.sender_id is not None
                 and run_id is not None
-                and self._active_runs.get(message.sender_id) == run_id
+                and self._active_runs.get(actor_id) == run_id
             ):
-                self._active_runs.pop(message.sender_id, None)
+                self._active_runs.pop(actor_id, None)
             if not rate_released:
                 await self._rate_limiter.release(
-                    user_id=message.sender_id,
+                    actor_id=actor_id,
                     is_owner=is_owner,
                 )
 
@@ -2439,6 +2570,7 @@ class AIConversationHandler:
         message: ReplyTarget,
     ) -> AIAnswerMarker | None:
         assert message.chat_id is not None
+        scope_id = self._identity_codec.scope_id(message.chat_id)
         current = await self._transport.get_reply(message)
         seen: set[tuple[int | None, int]] = set()
         for _ in range(self._prompt_builder.max_context_messages):
@@ -2448,15 +2580,18 @@ class AIConversationHandler:
             if identity in seen:
                 return None
             seen.add(identity)
-            turn = await self._store.get_turn_for_message(message.chat_id, current.id)
+            turn = await self._store.get_turn_for_message(scope_id, current.id)
             if turn is not None:
                 return turn
             current = await self._transport.get_reply(current)
         return None
 
-    async def _handle_cancel(self, message: ReplyTarget) -> bool:
-        assert message.sender_id is not None
-        run_id = self._active_runs.get(message.sender_id)
+    async def _handle_cancel(
+        self,
+        message: ReplyTarget,
+        actor_id: str,
+    ) -> bool:
+        run_id = self._active_runs.get(actor_id)
         if run_id is None:
             await self._reply_memory_excluded(
                 message,
@@ -2494,11 +2629,12 @@ class AIConversationHandler:
             )
             await self._delete_command_message(message, command.name)
             return True
+        target_actor_id = self._identity_codec.actor_id(target.sender_id)
         if command.allowed:
-            await self._store.allow_user(target.sender_id)
+            await self._store.allow_user(target_actor_id)
             response = "AI access allowed."
         else:
-            await self._store.deny_user(target.sender_id)
+            await self._store.deny_user(target_actor_id)
             response = "AI access denied."
         await self._reply_memory_excluded(message, response, kind="ai-control")
         await self._delete_command_message(message, command.name)
@@ -2763,25 +2899,29 @@ class AIConversationHandler:
         text: str,
         *,
         kind: str,
-    ) -> EditableMessage:
+    ) -> SentMessage:
         reply = await self._transport.reply(
             message,
             text,
             presentation="plain",
         )
         if message.chat_id is not None:
-            await self._mark_memory_excluded(message.chat_id, reply.id, kind)
+            await self._mark_memory_excluded(
+                self._identity_codec.scope_id(message.chat_id),
+                reply.id,
+                kind,
+            )
         return reply
 
     async def _mark_memory_excluded(
         self,
-        chat_id: int,
+        scope_id: str,
         message_id: int,
         kind: str,
     ) -> None:
         try:
             await self._store.mark_memory_excluded_message(
-                chat_id,
+                scope_id,
                 message_id,
                 kind,
             )
@@ -2790,7 +2930,7 @@ class AIConversationHandler:
 
     async def _classify_chat_context(
         self,
-        chat_id: int,
+        scope_id: str,
         context: ChatContext,
     ) -> tuple[
         frozenset[int],
@@ -2801,7 +2941,10 @@ class AIConversationHandler:
         uncertain_message_ids: set[int] = set()
         for message in context.messages:
             try:
-                marker = await self._store.get_answer(chat_id, message.message_id)
+                marker = await self._store.get_answer(
+                    scope_id,
+                    message.message_id,
+                )
             except Exception as exc:
                 self._log_memory_failure("AI-message filtering", exc)
                 uncertain_message_ids.add(message.message_id)
@@ -2904,7 +3047,10 @@ class AIConversationHandler:
             return True
         target_is_ai = False
         if target.chat_id is not None:
-            marker = await self._store.get_answer(target.chat_id, target.id)
+            marker = await self._store.get_answer(
+                self._identity_codec.scope_id(target.chat_id),
+                target.id,
+            )
             if marker is not None:
                 target_is_ai = True
         target_identity = await self._prompt_builder.resolve_identity(target)
@@ -3012,7 +3158,7 @@ class AIConversationHandler:
             return None
         loaded_context = await self._prompt_builder.load_reply_chain(target)
         _, _, observations = await self._classify_chat_context(
-            target.chat_id,
+            self._identity_codec.scope_id(target.chat_id),
             loaded_context,
         )
         if not observations:
@@ -3125,10 +3271,10 @@ class AIConversationHandler:
 
 def _marker_from_row(row: aiosqlite.Row) -> AIAnswerMarker:
     return AIAnswerMarker(
-        chat_id=row["chat_id"],
+        scope_id=str(row["scope_id"]),
         answer_message_id=row["answer_message_id"],
         trigger_message_id=row["trigger_message_id"],
-        requester_id=row["requester_id"],
+        requester_id=str(row["requester_id"]),
         prompt=row["prompt"],
         answer_text=row["answer_text"],
         parent_answer_message_id=row["parent_answer_message_id"],

--- a/src/telefire/ai_attachments.py
+++ b/src/telefire/ai_attachments.py
@@ -11,6 +11,8 @@ from typing import Any, Literal, Protocol
 from PIL import Image
 from pypdf import PdfReader
 
+from telefire.chat.attachments import AttachmentDescription
+
 
 AttachmentKind = Literal["image", "text"]
 _IMAGE_MIME_TYPES = {"image/jpeg", "image/png", "image/webp"}
@@ -60,18 +62,8 @@ class AttachmentAnalysisRequest:
             raise ValueError("Attachment analysis requires exactly one content type")
 
 
-@dataclass(frozen=True, slots=True)
-class AttachmentDescription:
-    context_text: str
-    memory_text: str
-
-
 class AttachmentAnalysisGateway(Protocol):
     async def describe_attachment(self, request: AttachmentAnalysisRequest) -> str: ...
-
-
-class AttachmentDescriber(Protocol):
-    async def describe(self, message: Any) -> AttachmentDescription | None: ...
 
 
 def message_has_attachment(message: Any) -> bool:
@@ -115,6 +107,9 @@ class TelegramAttachmentDescriber:
         self._gateway = gateway
         self._download_timeout = download_timeout
         self._logger = logger
+
+    def has_attachment(self, message: Any) -> bool:
+        return message_has_attachment(message)
 
     async def describe(self, message: Any) -> AttachmentDescription | None:
         file = getattr(message, "file", None)

--- a/src/telefire/ai_dream.py
+++ b/src/telefire/ai_dream.py
@@ -18,17 +18,19 @@ from telefire.ai import (
     MemoryDreamResult,
     PromptBuilder,
     ReplyTarget,
+    _chat_memory_episode,
     _memory_message_text,
     _message_datetime,
     _record_episode_labels,
-    _telegram_memory_event_metadata,
-    _telegram_memory_episode,
-    _telegram_scope_id,
 )
 from telefire.ai_attachments import attachment_metadata_only, message_has_attachment
 from telefire.chat.commands import (
     MAX_MEMORY_BACKFILL_MESSAGES,
     MemoryBackfillCommand,
+)
+from telefire.telegram.ai_identity import (
+    TELEGRAM_IDENTITY_CODEC,
+    telegram_memory_event_metadata,
 )
 from telefire.ai_memory import (
     MemoryClient,
@@ -485,7 +487,7 @@ class TelegramDreamScanner:
             )
         except DreamCycleTimeoutError as exc:
             await self._store.record_memory_dream_failure(
-                _telegram_scope_id(chat_id),
+                TELEGRAM_IDENTITY_CODEC.scope_id(chat_id),
                 failed_at=self._clock(),
                 error=f"{type(exc).__name__}: {exc}",
             )
@@ -539,7 +541,7 @@ class TelegramDreamScanner:
     ) -> Any:
         lock = self._locks.setdefault(chat_id, asyncio.Lock())
         async with lock:
-            scope_id = _telegram_scope_id(chat_id)
+            scope_id = TELEGRAM_IDENTITY_CODEC.scope_id(chat_id)
             acquired_at = self._clock()
             acquired = await self._store.acquire_memory_dream_lease(
                 scope_id,
@@ -577,7 +579,7 @@ class TelegramDreamScanner:
         self,
         chat_id: int,
     ) -> ContinuousMemoryResult:
-        scope_id = _telegram_scope_id(chat_id)
+        scope_id = TELEGRAM_IDENTITY_CODEC.scope_id(chat_id)
         scope = await self._store.get_memory_scope_state(scope_id)
         if not scope.continuous_enabled:
             raise ValueError("Continuous memory is disabled for this chat")
@@ -680,7 +682,7 @@ class TelegramDreamScanner:
 
     async def _run_scope(self, chat_id: int) -> MemoryDreamResult:
         deadline = self._monotonic() + self._settings.cycle_budget_seconds
-        scope_id = _telegram_scope_id(chat_id)
+        scope_id = TELEGRAM_IDENTITY_CODEC.scope_id(chat_id)
         scope = await self._store.get_memory_scope_state(scope_id)
         if scope.continuous_enabled:
             raise ValueError("Continuous memory overrides Dream for this chat")
@@ -873,7 +875,7 @@ class TelegramDreamScanner:
             for item in chain:
                 group[item.id] = item
 
-        scope_id = _telegram_scope_id(chat_id)
+        scope_id = TELEGRAM_IDENTITY_CODEC.scope_id(chat_id)
         source_ids = tuple(
             f"telegram:message:{chat_id}:{message_id}"
             for grouped in root_groups.values()
@@ -1042,7 +1044,8 @@ class TelegramDreamScanner:
             )
             if not observations:
                 continue
-            episode = _telegram_memory_episode(
+            episode = _chat_memory_episode(
+                TELEGRAM_IDENTITY_CODEC,
                 chat_id,
                 observations,
                 document_id=document_id,
@@ -1220,7 +1223,7 @@ class TelegramDreamScanner:
                     identity=identity,
                     reply_to_message_id=message.reply_to_msg_id,
                     mentioned_users=mentioned_users,
-                    metadata=_telegram_memory_event_metadata(message),
+                    metadata=telegram_memory_event_metadata(message),
                 )
 
         observations = await asyncio.gather(*(build(message) for message in messages))

--- a/src/telefire/ai_dream.py
+++ b/src/telefire/ai_dream.py
@@ -15,8 +15,6 @@ from telethon.errors import FloodWaitError
 from telefire.ai import (
     AIStateRepository,
     HumanObservation,
-    MAX_MEMORY_BACKFILL_MESSAGES,
-    MemoryBackfillRequest,
     MemoryDreamResult,
     PromptBuilder,
     ReplyTarget,
@@ -28,6 +26,10 @@ from telefire.ai import (
     _telegram_scope_id,
 )
 from telefire.ai_attachments import attachment_metadata_only, message_has_attachment
+from telefire.chat.commands import (
+    MAX_MEMORY_BACKFILL_MESSAGES,
+    MemoryBackfillCommand,
+)
 from telefire.ai_memory import (
     MemoryClient,
     MemoryClientError,
@@ -517,7 +519,7 @@ class TelegramDreamScanner:
     async def run_backfill(
         self,
         chat_id: int,
-        request: MemoryBackfillRequest,
+        request: MemoryBackfillCommand,
     ) -> MemoryDreamResult:
         return await self._run_exclusive(
             chat_id,
@@ -649,7 +651,7 @@ class TelegramDreamScanner:
     async def _run_backfill(
         self,
         chat_id: int,
-        request: MemoryBackfillRequest,
+        request: MemoryBackfillCommand,
     ) -> MemoryDreamResult:
         until = (
             datetime.fromtimestamp(self._clock(), UTC) - self._settings.settlement_delay

--- a/src/telefire/ai_dream.py
+++ b/src/telefire/ai_dream.py
@@ -1149,9 +1149,10 @@ class TelegramDreamScanner:
         messages: tuple[ReplyTarget, ...],
     ) -> dict[int, HumanObservation]:
         message_ids = tuple(message.id for message in messages)
+        scope_id = TELEGRAM_IDENTITY_CODEC.scope_id(chat_id)
         excluded_ids, answer_ids = await asyncio.gather(
-            self._store.get_memory_excluded_message_ids(chat_id, message_ids),
-            self._store.get_ai_answer_message_ids(chat_id, message_ids),
+            self._store.get_memory_excluded_message_ids(scope_id, message_ids),
+            self._store.get_ai_answer_message_ids(scope_id, message_ids),
         )
         semaphore = asyncio.Semaphore(self._settings.preprocess_concurrency)
         identity_semaphore = asyncio.Semaphore(self._settings.preprocess_concurrency)

--- a/src/telefire/chat/__init__.py
+++ b/src/telefire/chat/__init__.py
@@ -1,0 +1,1 @@
+"""Transport-neutral chat contracts used by Telefire features."""

--- a/src/telefire/chat/attachments.py
+++ b/src/telefire/chat/attachments.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol
+
+
+AttachmentKind = Literal[
+    "image",
+    "audio",
+    "video",
+    "text",
+    "file",
+    "sticker",
+    "other",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class AttachmentReference:
+    """Metadata and an opaque adapter key, never attachment payload bytes."""
+
+    key: str
+    kind: AttachmentKind
+    mime_type: str
+    filename: str | None = None
+    size_bytes: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.key.strip():
+            raise ValueError("Attachment reference key cannot be empty")
+        if not self.mime_type.strip():
+            raise ValueError("Attachment MIME type cannot be empty")
+        if self.size_bytes is not None and self.size_bytes < 0:
+            raise ValueError("Attachment size cannot be negative")
+
+
+@dataclass(frozen=True, slots=True)
+class AttachmentDescription:
+    context_text: str
+    memory_text: str
+
+
+class AttachmentDescriber(Protocol):
+    def has_attachment(self, message: Any) -> bool: ...
+
+    async def describe(self, message: Any) -> AttachmentDescription | None: ...

--- a/src/telefire/chat/commands.py
+++ b/src/telefire/chat/commands.py
@@ -23,6 +23,10 @@ class AICancelCommand:
 class AccessCommand:
     allowed: bool
 
+    @property
+    def name(self) -> str:
+        return "/ai_allow" if self.allowed else "/ai_deny"
+
 
 @dataclass(frozen=True, slots=True)
 class MemoryRememberCommand:
@@ -34,12 +38,27 @@ class MemoryBackfillCommand:
     mode: Literal["days", "messages"]
     value: int
 
+    def __post_init__(self) -> None:
+        maximum = (
+            MAX_MEMORY_BACKFILL_DAYS
+            if self.mode == "days"
+            else MAX_MEMORY_BACKFILL_MESSAGES
+        )
+        if self.mode not in {"days", "messages"} or not 1 <= self.value <= maximum:
+            raise ValueError("Memory backfill request is outside supported bounds")
+
 
 @dataclass(frozen=True, slots=True)
 class MemoryModeCommand:
     mode: Literal["continuous", "dream"]
     enabled: bool
     target: str | None = None
+
+    @property
+    def name(self) -> str:
+        prefix = "/ai_memory" if self.mode == "continuous" else "/ai_dream"
+        suffix = "enable" if self.enabled else "disable"
+        return f"{prefix}_{suffix}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,14 +103,19 @@ def parse_chat_command(text: str | None) -> ChatCommand | None:
     if ai is not None:
         return ai
 
-    if text == "/ai_cancel":
+    memory_revision = _parse_memory_revision(text)
+    if memory_revision is not None:
+        return memory_revision
+
+    control = text.strip()
+    if control == "/ai_cancel":
         return AICancelCommand()
-    if text == "/ai_allow":
+    if control == "/ai_allow":
         return AccessCommand(allowed=True)
-    if text == "/ai_deny":
+    if control == "/ai_deny":
         return AccessCommand(allowed=False)
 
-    memory = _parse_memory(text)
+    memory = _parse_memory_control(control)
     if memory is not None:
         return memory
     return None
@@ -124,14 +148,17 @@ def _parse_ai(text: str) -> AIAskCommand | None:
     )
 
 
-def _parse_memory(text: str) -> ChatCommand | None:
+def _parse_memory_revision(text: str) -> MemoryRememberCommand | None:
     if text == "/ai_memory":
         return MemoryRememberCommand(instruction="")
     if text.startswith(("/ai_memory ", "/ai_memory\n", "/ai_memory\t")):
         return MemoryRememberCommand(
             instruction=text[len("/ai_memory") :].strip()
         )
+    return None
 
+
+def _parse_memory_control(text: str) -> ChatCommand | None:
     parts = text.split()
     if not parts:
         return None

--- a/src/telefire/chat/commands.py
+++ b/src/telefire/chat/commands.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+
+MAX_MEMORY_BACKFILL_DAYS = 30
+MAX_MEMORY_BACKFILL_MESSAGES = 5_000
+
+
+@dataclass(frozen=True, slots=True)
+class AIAskCommand:
+    prompt: str
+    recent_messages: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AICancelCommand:
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class AccessCommand:
+    allowed: bool
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRememberCommand:
+    instruction: str
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryBackfillCommand:
+    mode: Literal["days", "messages"]
+    value: int
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryModeCommand:
+    mode: Literal["continuous", "dream"]
+    enabled: bool
+    target: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryStatusCommand:
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryListCommand:
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryDreamCommand:
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class InvalidCommand:
+    name: str
+
+
+ChatCommand: TypeAlias = (
+    AIAskCommand
+    | AICancelCommand
+    | AccessCommand
+    | MemoryRememberCommand
+    | MemoryBackfillCommand
+    | MemoryModeCommand
+    | MemoryStatusCommand
+    | MemoryListCommand
+    | MemoryDreamCommand
+    | InvalidCommand
+)
+
+
+def parse_chat_command(text: str | None) -> ChatCommand | None:
+    if text is None or not text.startswith("/"):
+        return None
+
+    ai = _parse_ai(text)
+    if ai is not None:
+        return ai
+
+    if text == "/ai_cancel":
+        return AICancelCommand()
+    if text == "/ai_allow":
+        return AccessCommand(allowed=True)
+    if text == "/ai_deny":
+        return AccessCommand(allowed=False)
+
+    memory = _parse_memory(text)
+    if memory is not None:
+        return memory
+    return None
+
+
+def _parse_ai(text: str) -> AIAskCommand | None:
+    if not text.casefold().startswith("/ai"):
+        return None
+    cursor = 3
+    digit_start = cursor
+    while cursor < len(text) and text[cursor].isascii() and text[cursor].isdigit():
+        cursor += 1
+    recent_messages = (
+        int(text[digit_start:cursor]) if cursor > digit_start else None
+    )
+    if cursor < len(text) and text[cursor] == "@":
+        cursor += 1
+        mention_start = cursor
+        while cursor < len(text) and text[cursor] not in " \n\t\r":
+            cursor += 1
+        if cursor == mention_start:
+            return None
+    if cursor == len(text):
+        return AIAskCommand(prompt="", recent_messages=recent_messages)
+    if text[cursor] not in " \n\t\r":
+        return None
+    return AIAskCommand(
+        prompt=text[cursor:].strip(),
+        recent_messages=recent_messages,
+    )
+
+
+def _parse_memory(text: str) -> ChatCommand | None:
+    if text == "/ai_memory":
+        return MemoryRememberCommand(instruction="")
+    if text.startswith(("/ai_memory ", "/ai_memory\n", "/ai_memory\t")):
+        return MemoryRememberCommand(
+            instruction=text[len("/ai_memory") :].strip()
+        )
+
+    parts = text.split()
+    if not parts:
+        return None
+    name = parts[0]
+    if name == "/ai_memory_backfill":
+        if len(parts) != 3 or parts[1] not in {"days", "messages"}:
+            return InvalidCommand(name=name)
+        try:
+            value = int(parts[2])
+        except ValueError:
+            return InvalidCommand(name=name)
+        maximum = (
+            MAX_MEMORY_BACKFILL_DAYS
+            if parts[1] == "days"
+            else MAX_MEMORY_BACKFILL_MESSAGES
+        )
+        if not 1 <= value <= maximum:
+            return InvalidCommand(name=name)
+        return MemoryBackfillCommand(mode=parts[1], value=value)
+
+    mode_commands = {
+        "/ai_memory_enable": ("continuous", True),
+        "/ai_memory_disable": ("continuous", False),
+        "/ai_dream_enable": ("dream", True),
+        "/ai_dream_disable": ("dream", False),
+    }
+    if name in mode_commands:
+        if len(parts) > 2:
+            return InvalidCommand(name=name)
+        mode, enabled = mode_commands[name]
+        return MemoryModeCommand(
+            mode=mode,
+            enabled=enabled,
+            target=parts[1] if len(parts) == 2 else None,
+        )
+    if text == "/ai_memory_status":
+        return MemoryStatusCommand()
+    if text == "/ai_memory_list":
+        return MemoryListCommand()
+    if text == "/ai_memory_dream":
+        return MemoryDreamCommand()
+    return None

--- a/src/telefire/chat/identity.py
+++ b/src/telefire/chat/identity.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.parse import quote
+
+
+ExternalId = int | str
+
+
+class IdentityCodec(Protocol):
+    source: str
+
+    def actor_id(self, actor_id: ExternalId) -> str: ...
+
+    def scope_id(self, scope_id: ExternalId) -> str: ...
+
+    def message_source_id(
+        self,
+        scope_id: ExternalId,
+        message_id: ExternalId,
+    ) -> str: ...
+
+    def thread_document_id(
+        self,
+        scope_id: ExternalId,
+        root_message_id: ExternalId,
+    ) -> str: ...
+
+    def revision_document_id(
+        self,
+        scope_id: ExternalId,
+        message_id: ExternalId,
+    ) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class NamespacedIdentityCodec:
+    source: str
+    actor_kind: str
+    scope_kind: str
+
+    def __post_init__(self) -> None:
+        for value in (self.source, self.actor_kind, self.scope_kind):
+            if not value or any(character in value for character in ": \t\r\n"):
+                raise ValueError("Identity namespace components must be non-empty tokens")
+
+    def actor_id(self, actor_id: ExternalId) -> str:
+        return f"{self.source}:{self.actor_kind}:{_component(actor_id)}"
+
+    def scope_id(self, scope_id: ExternalId) -> str:
+        return f"{self.source}:{self.scope_kind}:{_component(scope_id)}"
+
+    def message_source_id(
+        self,
+        scope_id: ExternalId,
+        message_id: ExternalId,
+    ) -> str:
+        return (
+            f"{self.source}:message:{_component(scope_id)}:"
+            f"{_component(message_id)}"
+        )
+
+    def thread_document_id(
+        self,
+        scope_id: ExternalId,
+        root_message_id: ExternalId,
+    ) -> str:
+        return (
+            f"{self.source}:thread:{_component(scope_id)}:"
+            f"{_component(root_message_id)}"
+        )
+
+    def revision_document_id(
+        self,
+        scope_id: ExternalId,
+        message_id: ExternalId,
+    ) -> str:
+        return (
+            f"{self.source}:revision:{_component(scope_id)}:"
+            f"{_component(message_id)}"
+        )
+
+
+def _component(value: ExternalId) -> str:
+    if isinstance(value, bool):
+        raise ValueError("Boolean values are not valid external IDs")
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError("External IDs cannot be empty")
+    return quote(normalized, safe="-_.~")

--- a/src/telefire/chat/transport.py
+++ b/src/telefire/chat/transport.py
@@ -7,7 +7,7 @@ ChatPresentation = Literal["plain", "agent"]
 
 
 class SentMessage(Protocol):
-    id: int | str
+    id: int
     text: str | None
 
 

--- a/src/telefire/chat/transport.py
+++ b/src/telefire/chat/transport.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol
+
+
+ChatPresentation = Literal["plain", "agent"]
+
+
+class SentMessage(Protocol):
+    id: int | str
+    text: str | None
+
+
+class ChatTransport(Protocol):
+    async def get_reply(self, message: Any) -> Any | None: ...
+
+    async def reply(
+        self,
+        message: Any,
+        text: str,
+        *,
+        presentation: ChatPresentation,
+    ) -> SentMessage: ...
+
+    async def update(
+        self,
+        message: SentMessage,
+        text: str,
+        *,
+        presentation: ChatPresentation,
+        wait: bool,
+    ) -> bool: ...
+
+    async def delete(self, message: Any) -> None: ...
+
+    def is_outgoing(self, message: Any) -> bool: ...

--- a/src/telefire/chat/transport.py
+++ b/src/telefire/chat/transport.py
@@ -34,3 +34,48 @@ class ChatTransport(Protocol):
     async def delete(self, message: Any) -> None: ...
 
     def is_outgoing(self, message: Any) -> bool: ...
+
+
+class ObjectChatTransport:
+    """Adapter for SDK message objects exposing reply/edit/delete methods."""
+
+    async def get_reply(self, message: Any) -> Any | None:
+        operation = getattr(message, "get_reply_message", None)
+        return await operation() if callable(operation) else None
+
+    async def reply(
+        self,
+        message: Any,
+        text: str,
+        *,
+        presentation: ChatPresentation,
+    ) -> SentMessage:
+        operation = getattr(message, "reply", None)
+        if not callable(operation):
+            raise RuntimeError("Chat transport cannot reply to this message")
+        return await operation(text)
+
+    async def update(
+        self,
+        message: SentMessage,
+        text: str,
+        *,
+        presentation: ChatPresentation,
+        wait: bool,
+    ) -> bool:
+        operation = getattr(message, "edit", None)
+        if not callable(operation):
+            raise RuntimeError("Chat transport cannot update this message")
+        await operation(text)
+        return True
+
+    async def delete(self, message: Any) -> None:
+        operation = getattr(message, "delete", None)
+        if callable(operation):
+            await operation()
+
+    def is_outgoing(self, message: Any) -> bool:
+        outgoing = getattr(message, "is_outgoing", None)
+        if outgoing is None:
+            outgoing = getattr(message, "out", False)
+        return bool(outgoing)

--- a/src/telefire/plugins/ai.py
+++ b/src/telefire/plugins/ai.py
@@ -16,11 +16,9 @@ from telefire.ai import (
     AIStateRepository,
     PiAgentGateway,
     PromptBuilder,
-    TelegramEditLimiter,
     TelegramMemoryScopeTargetResolver,
     TelegramMessageIdentityResolver,
     TelegramMessageMentionResolver,
-    select_telegram_response_format,
 )
 from telefire.ai_attachments import TelegramAttachmentDescriber
 from telefire.ai_dream import (
@@ -35,6 +33,12 @@ from telefire.ai_dream import (
 from telefire.ai_memory import HindsightMemoryClient
 from telefire.plugins.base import PluginMount
 from telefire.telegram import TelegramCommand
+from telefire.telegram.ai_transport import (
+    TelegramChatTransport,
+    TelegramEditLimiter,
+    select_telegram_response_format,
+    telegram_system_prompt,
+)
 
 
 class _SavedMemoryForwardSourceUnavailable(RuntimeError):
@@ -205,21 +209,27 @@ class TelegramAI(TelegramCommand, metaclass=PluginMount):
             is_bot_account=bool(getattr(owner, "bot", False)),
             rich_messages_available=True,
         )
+        transport = TelegramChatTransport(
+            response_format=response_format,
+            edit_limiter=self._edit_limiter,
+            logger=self.logger,
+        )
         responder = AIResponder(
             self._gateway,
             max_output_chars=self._settings.max_output_chars,
-            response_format=response_format,
-            edit_limiter=self._edit_limiter,
+            transport=transport,
             logger=self.logger,
         )
         self._responder = responder
         await self._store.connect()
         history_source = TelegramHistorySource(self.client)
         prompt_builder = PromptBuilder(
-            system_prompt=self._settings.system_prompt,
+            system_prompt=telegram_system_prompt(
+                self._settings.system_prompt,
+                response_format,
+            ),
             max_context_messages=self._settings.max_context_messages,
             max_context_chars=self._settings.max_context_chars,
-            response_format=response_format,
             attachment_describer=TelegramAttachmentDescriber(
                 self._gateway,
                 logger=self.logger,
@@ -232,6 +242,7 @@ class TelegramAI(TelegramCommand, metaclass=PluginMount):
                 logger=self.logger,
             ),
             history_source=history_source,
+            transport=transport,
         )
         dream_runner = (
             TelegramDreamScanner(
@@ -276,6 +287,7 @@ class TelegramAI(TelegramCommand, metaclass=PluginMount):
             memory_command_delete_delay=(
                 self._settings.memory_command_delete_delay
             ),
+            transport=transport,
             logger=self.logger,
         )
         self.client.add_event_handler(self._on_message, events.NewMessage())

--- a/src/telefire/plugins/ai.py
+++ b/src/telefire/plugins/ai.py
@@ -16,9 +16,6 @@ from telefire.ai import (
     AIStateRepository,
     PiAgentGateway,
     PromptBuilder,
-    TelegramMemoryScopeTargetResolver,
-    TelegramMessageIdentityResolver,
-    TelegramMessageMentionResolver,
 )
 from telefire.ai_attachments import TelegramAttachmentDescriber
 from telefire.ai_dream import (
@@ -38,6 +35,13 @@ from telefire.telegram.ai_transport import (
     TelegramEditLimiter,
     select_telegram_response_format,
     telegram_system_prompt,
+)
+from telefire.telegram.ai_identity import (
+    TELEGRAM_IDENTITY_CODEC,
+    TelegramMemoryScopeTargetResolver,
+    TelegramMessageIdentityResolver,
+    TelegramMessageMentionResolver,
+    telegram_memory_event_metadata,
 )
 
 
@@ -243,6 +247,8 @@ class TelegramAI(TelegramCommand, metaclass=PluginMount):
             ),
             history_source=history_source,
             transport=transport,
+            identity_codec=TELEGRAM_IDENTITY_CODEC,
+            metadata_resolver=telegram_memory_event_metadata,
         )
         dream_runner = (
             TelegramDreamScanner(
@@ -288,6 +294,7 @@ class TelegramAI(TelegramCommand, metaclass=PluginMount):
                 self._settings.memory_command_delete_delay
             ),
             transport=transport,
+            identity_codec=TELEGRAM_IDENTITY_CODEC,
             logger=self.logger,
         )
         self.client.add_event_handler(self._on_message, events.NewMessage())

--- a/src/telefire/telegram/ai_identity.py
+++ b/src/telefire/telegram/ai_identity.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+from telethon import helpers as telegram_helpers
+from telethon import utils as telegram_utils
+from telethon.tl import types as telegram_types
+
+from telefire.ai import (
+    MemoryScopeTarget,
+    MentionedUser,
+    MessageIdentity,
+    ReplyTarget,
+)
+from telefire.chat.identity import IdentityCodec, NamespacedIdentityCodec
+
+
+TELEGRAM_IDENTITY_CODEC = NamespacedIdentityCodec(
+    source="telegram",
+    actor_kind="user",
+    scope_kind="chat",
+)
+_TELEGRAM_CHANNEL_CODEC = NamespacedIdentityCodec(
+    source="telegram",
+    actor_kind="channel",
+    scope_kind="chat",
+)
+
+
+class TelegramMessageIdentityResolver:
+    def __init__(
+        self,
+        *,
+        codec: IdentityCodec = TELEGRAM_IDENTITY_CODEC,
+        logger: Any | None = None,
+    ):
+        self._codec = codec
+        self._logger = logger
+
+    async def resolve(self, message: ReplyTarget) -> MessageIdentity:
+        sender, chat = await asyncio.gather(
+            self._load_entity(message, "get_sender"),
+            self._load_entity(message, "get_chat"),
+        )
+        is_human = (
+            isinstance(sender, telegram_types.User)
+            and not bool(getattr(sender, "bot", False))
+        )
+        is_broadcast_channel_post = (
+            isinstance(sender, telegram_types.Channel)
+            and isinstance(chat, telegram_types.Channel)
+            and bool(getattr(chat, "broadcast", False))
+            and sender.id == chat.id
+        )
+        return MessageIdentity(
+            subject_id=(
+                self._codec.actor_id(sender.id)
+                if is_human
+                else _TELEGRAM_CHANNEL_CODEC.actor_id(sender.id)
+                if is_broadcast_channel_post
+                else None
+            ),
+            subject_display_name=telegram_display_name(sender),
+            scope_display_name=telegram_display_name(chat),
+            is_human=is_human,
+        )
+
+    async def _load_entity(self, message: ReplyTarget, method_name: str) -> Any | None:
+        method = getattr(message, method_name, None)
+        if not callable(method):
+            return None
+        try:
+            return await method()
+        except Exception as exc:
+            if self._logger is not None:
+                self._logger.debug(
+                    "Telegram identity lookup failed (%s): %s",
+                    type(exc).__name__,
+                    exc,
+                )
+            return None
+
+
+class TelegramMessageMentionResolver:
+    def __init__(
+        self,
+        client: Any,
+        *,
+        logger: Any | None = None,
+    ):
+        self._client = client
+        self._logger = logger
+
+    async def resolve(self, message: ReplyTarget) -> tuple[MentionedUser, ...]:
+        text = message.raw_text or ""
+        surrogate_text = telegram_helpers.add_surrogate(text)
+        resolved: dict[int, MentionedUser] = {}
+        for entity in getattr(message, "entities", None) or ():
+            candidate: Any | None = None
+            if isinstance(entity, telegram_types.MessageEntityMentionName):
+                candidate = entity.user_id
+            elif isinstance(entity, telegram_types.MessageEntityMention):
+                mention = telegram_helpers.del_surrogate(
+                    surrogate_text[entity.offset : entity.offset + entity.length]
+                )
+                if not mention.startswith("@") or len(mention) < 2:
+                    continue
+                candidate = mention
+            else:
+                continue
+            try:
+                actor = await self._client.get_entity(candidate)
+            except Exception as exc:
+                if self._logger is not None:
+                    self._logger.debug(
+                        "Telegram mention lookup failed (%s): %s",
+                        type(exc).__name__,
+                        exc,
+                    )
+                continue
+            user_id = getattr(actor, "id", None)
+            if not isinstance(user_id, int) or user_id <= 0:
+                continue
+            resolved[user_id] = MentionedUser(
+                user_id=user_id,
+                display_name=telegram_display_name(actor),
+            )
+        return tuple(resolved.values())
+
+
+class TelegramMemoryScopeTargetResolver:
+    def __init__(self, client: Any, *, logger: Any | None = None):
+        self._client = client
+        self._logger = logger
+
+    async def resolve(
+        self,
+        target: str,
+        *,
+        include_latest_message: bool = False,
+    ) -> MemoryScopeTarget:
+        digits = target.removeprefix("-")
+        if (
+            not digits
+            or not digits.isascii()
+            or not digits.isdecimal()
+            or int(target) == 0
+        ):
+            raise ValueError("Telegram target must be a non-zero numeric chat ID")
+        chat_id = int(target)
+        try:
+            entity = await self._client.get_entity(chat_id)
+            if not isinstance(
+                entity,
+                (telegram_types.Chat, telegram_types.Channel),
+            ):
+                raise ValueError("Telegram target is not a group or channel")
+            latest_message_id = 0
+            if include_latest_message:
+                messages = await self._client.get_messages(entity, limit=1)
+                if messages:
+                    latest_message_id = int(messages[0].id)
+        except Exception as exc:
+            if self._logger is not None:
+                self._logger.warning(
+                    "Telegram memory scope lookup failed "
+                    "(chat_id=%s, error=%s): %s",
+                    chat_id,
+                    type(exc).__name__,
+                    exc,
+                )
+            raise ValueError(
+                "Telegram group or channel is inaccessible"
+            ) from exc
+        return MemoryScopeTarget(
+            chat_id=telegram_utils.get_peer_id(entity),
+            display_name=telegram_display_name(entity),
+            latest_message_id=latest_message_id,
+        )
+
+
+def telegram_memory_event_metadata(
+    message: ReplyTarget,
+    *,
+    codec: IdentityCodec = TELEGRAM_IDENTITY_CODEC,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    chat_id = getattr(message, "chat_id", None)
+    post_author = getattr(message, "post_author", None)
+    if isinstance(post_author, str) and post_author.strip():
+        metadata["post_author"] = post_author.strip()[:256]
+    reply = getattr(message, "reply_to", None)
+    quote_text = getattr(reply, "quote_text", None)
+    if isinstance(quote_text, str) and quote_text.strip():
+        quotation: dict[str, Any] = {"text": quote_text.strip()[:4_000]}
+        reply_id = getattr(message, "reply_to_msg_id", None)
+        if isinstance(chat_id, int) and isinstance(reply_id, int):
+            quotation["source_id"] = codec.message_source_id(chat_id, reply_id)
+        quote_offset = getattr(reply, "quote_offset", None)
+        if isinstance(quote_offset, int) and quote_offset >= 0:
+            quotation["offset"] = quote_offset
+        metadata["quotation"] = quotation
+
+    forward = getattr(message, "fwd_from", None)
+    if forward is not None:
+        attribution: dict[str, Any] = {}
+        from_name = getattr(forward, "from_name", None)
+        if isinstance(from_name, str) and from_name.strip():
+            attribution["actor_display_name"] = from_name.strip()[:256]
+        from_id = getattr(forward, "from_id", None)
+        if isinstance(from_id, telegram_types.PeerUser):
+            attribution["actor_id"] = codec.actor_id(from_id.user_id)
+        source_peer = getattr(forward, "saved_from_peer", None) or from_id
+        source_message_id = getattr(forward, "saved_from_msg_id", None) or getattr(
+            forward,
+            "channel_post",
+            None,
+        )
+        if source_peer is not None and isinstance(source_message_id, int):
+            try:
+                source_chat_id = telegram_utils.get_peer_id(source_peer)
+            except (TypeError, ValueError):
+                source_chat_id = None
+            if isinstance(source_chat_id, int):
+                attribution["source_id"] = codec.message_source_id(
+                    source_chat_id,
+                    source_message_id,
+                )
+        forwarded_at = getattr(forward, "date", None)
+        if isinstance(forwarded_at, datetime):
+            if forwarded_at.tzinfo is None:
+                forwarded_at = forwarded_at.replace(tzinfo=UTC)
+            attribution["source_time"] = (
+                forwarded_at.astimezone(UTC).isoformat().replace("+00:00", "Z")
+            )
+        if attribution:
+            metadata["forwarded_from"] = attribution
+    return metadata
+
+
+def telegram_display_name(entity: Any | None) -> str | None:
+    if entity is None:
+        return None
+    display_name = telegram_utils.get_display_name(entity).strip()
+    if not display_name:
+        username = (getattr(entity, "username", None) or "").strip()
+        display_name = f"@{username}" if username else ""
+    display_name = " ".join(display_name.split())
+    return display_name[:256] or None

--- a/src/telefire/telegram/ai_transport.py
+++ b/src/telefire/telegram/ai_transport.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal
+
+from telethon.errors import FloodWaitError, MessageNotModifiedError
+from telethon.extensions import html as telegram_html
+from telethon.tl import functions as telegram_functions
+from telethon.tl import types as telegram_types
+
+from telefire.chat.transport import ChatPresentation, SentMessage
+
+
+TelegramResponseFormat = Literal["regular_html", "rich_markdown"]
+TELEGRAM_REGULAR_HTML_FORMAT_GUIDE = """Response format: Telegram regular-message HTML.
+- Return only the answer. Do not wrap the whole response in a code block.
+- Use only these formatting tags: <b>bold</b>, <i>italic</i>, <u>underline</u>, <s>strikethrough</s>, <code>inline code</code>, <pre>preformatted block</pre>, <blockquote>quoted text</blockquote>, and <a href="https://example.com">link text</a>.
+- Use a short <b>bold heading</b> on its own line instead of Markdown headings. Use plain hyphen or numbered lines for lists.
+- Telegram regular messages have no native table entity. Render a compact table as aligned text inside <pre>; render a wide table as labeled list rows.
+- Escape literal <, >, and & as &lt;, &gt;, and &amp;. Close every tag. Do not nest formatting inside <code> or <pre>.
+- Do not emit Markdown markers such as **, __, # headings, > quotes, backticks, or pipe-table syntax."""
+TELEGRAM_RICH_MARKDOWN_FORMAT_GUIDE = """Response format: Telegram Bot API rich-message Markdown.
+- Return only the answer. Use GitHub-Flavored Markdown where possible.
+- Use **bold**, *italic*, ~~strikethrough~~, `inline code`, fenced code blocks, # headings, > blockquotes, lists, and links.
+- Native tables use this structure:
+| Header 1 | Header 2 |
+|:---------|:---------|
+| Value 1  | Value 2  |
+- Keep tables compact, close every formatting delimiter and code fence, and do not wrap the whole response in a code block."""
+
+
+def select_telegram_response_format(
+    *,
+    is_bot_account: bool,
+    rich_messages_available: bool,
+) -> TelegramResponseFormat:
+    if is_bot_account and rich_messages_available:
+        return "rich_markdown"
+    return "regular_html"
+
+
+def telegram_system_prompt(
+    base_prompt: str,
+    response_format: TelegramResponseFormat = "regular_html",
+) -> str:
+    if response_format == "regular_html":
+        guide = TELEGRAM_REGULAR_HTML_FORMAT_GUIDE
+    elif response_format == "rich_markdown":
+        guide = TELEGRAM_RICH_MARKDOWN_FORMAT_GUIDE
+    else:
+        raise ValueError(f"Unsupported Telegram response format: {response_format}")
+    return f"{base_prompt.rstrip()}\n\n{guide}".lstrip()
+
+
+class TelegramEditLimiter:
+    def __init__(
+        self,
+        minimum_interval: float,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[None]] | None = None,
+        logger: Any | None = None,
+    ):
+        self._minimum_interval = max(0.0, minimum_interval)
+        self._clock = clock
+        self._sleep = sleep or asyncio.sleep
+        self._logger = logger
+        self._lock = asyncio.Lock()
+        self._next_edit_at = 0.0
+
+    async def run(
+        self,
+        operation: Callable[[], Awaitable[Any]],
+        *,
+        wait: bool,
+    ) -> bool:
+        if not wait and self._lock.locked():
+            return False
+
+        async with self._lock:
+            while True:
+                now = self._clock()
+                delay = self._next_edit_at - now
+                if delay > 0:
+                    if not wait:
+                        return False
+                    await self._sleep(delay)
+                    now = self._next_edit_at
+                    self._next_edit_at = 0.0
+
+                try:
+                    await operation()
+                except FloodWaitError as exc:
+                    seconds = max(0.0, float(exc.seconds))
+                    self._next_edit_at = now + seconds
+                    if self._logger is not None:
+                        self._logger.warning(
+                            "Telegram edit rate limited; waiting %.0f seconds",
+                            seconds,
+                        )
+                    if not wait:
+                        return False
+                    continue
+                except MessageNotModifiedError:
+                    self._next_edit_at = now + self._minimum_interval
+                    return True
+                except Exception:
+                    self._next_edit_at = now + self._minimum_interval
+                    raise
+
+                self._next_edit_at = now + self._minimum_interval
+                return True
+
+
+class TelegramChatTransport:
+    def __init__(
+        self,
+        response_format: TelegramResponseFormat = "regular_html",
+        *,
+        edit_limiter: TelegramEditLimiter | None = None,
+        edit_cadence: float = 4.0,
+        clock: Callable[[], float] = time.monotonic,
+        logger: Any | None = None,
+    ):
+        self._response_format = response_format
+        self._edit_limiter = edit_limiter or TelegramEditLimiter(
+            edit_cadence,
+            clock=clock,
+            logger=logger,
+        )
+
+    async def get_reply(self, message: Any) -> Any | None:
+        operation = getattr(message, "get_reply_message", None)
+        return await operation() if callable(operation) else None
+
+    async def reply(
+        self,
+        message: Any,
+        text: str,
+        *,
+        presentation: ChatPresentation,
+    ) -> SentMessage:
+        operation = getattr(message, "reply", None)
+        if not callable(operation):
+            raise RuntimeError("Telegram message cannot be replied to")
+        return await operation(text, parse_mode=None)
+
+    async def update(
+        self,
+        message: SentMessage,
+        text: str,
+        *,
+        presentation: ChatPresentation,
+        wait: bool,
+    ) -> bool:
+        if presentation == "plain":
+            return await self._edit_limiter.run(
+                lambda: message.edit(text, parse_mode=None),
+                wait=wait,
+            )
+        if self._response_format == "rich_markdown":
+            return await self._update_rich_markdown(message, text, wait=wait)
+        rendered, entities = telegram_html.parse(text)
+        if not rendered.strip():
+            return False
+        return await self._edit_limiter.run(
+            lambda: message.edit(
+                rendered,
+                parse_mode=None,
+                formatting_entities=entities,
+            ),
+            wait=wait,
+        )
+
+    async def delete(self, message: Any) -> None:
+        operation = getattr(message, "delete", None)
+        if callable(operation):
+            await operation()
+
+    def is_outgoing(self, message: Any) -> bool:
+        return bool(getattr(message, "out", False))
+
+    async def _update_rich_markdown(
+        self,
+        message: SentMessage,
+        text: str,
+        *,
+        wait: bool,
+    ) -> bool:
+        if not text.strip().strip("*_~`#>|:-"):
+            return False
+        client = getattr(message, "client", None)
+        get_input_chat = getattr(message, "get_input_chat", None)
+        if client is None or not callable(get_input_chat):
+            raise RuntimeError("Telegram rich-message editing is unavailable")
+        peer = await get_input_chat()
+        if peer is None:
+            raise RuntimeError("Telegram rich-message peer is unavailable")
+
+        async def edit() -> None:
+            await client(
+                telegram_functions.messages.EditMessageRequest(
+                    peer=peer,
+                    id=message.id,
+                    rich_message=telegram_types.InputRichMessageMarkdown(
+                        markdown=text
+                    ),
+                )
+            )
+
+        return await self._edit_limiter.run(edit, wait=wait)

--- a/tests/test_ai_access.py
+++ b/tests/test_ai_access.py
@@ -12,6 +12,11 @@ from telefire.ai import (
     AgentRunRequest,
     PromptBuilder,
 )
+from telefire.telegram.ai_identity import TELEGRAM_IDENTITY_CODEC
+
+
+def actor_id(user_id: int) -> str:
+    return TELEGRAM_IDENTITY_CODEC.actor_id(user_id)
 
 
 class FakeAnswer:
@@ -116,8 +121,11 @@ async def make_handler(path, gateway, *, clock=lambda: 100.0, cooldown=30.0):
         owner_id=10,
         responder=AIResponder(gateway),
         store=store,
-        prompt_builder=PromptBuilder(),
+        prompt_builder=PromptBuilder(
+            identity_codec=TELEGRAM_IDENTITY_CODEC,
+        ),
         rate_limiter=limiter,
+        identity_codec=TELEGRAM_IDENTITY_CODEC,
     )
     return handler, store
 
@@ -137,7 +145,7 @@ async def test_owner_can_allow_user_who_can_start_continue_and_fork(tmp_path):
         allow = FakeMessage("/ai_allow", sender_id=10, reply_to=target)
 
         assert await handler.handle(allow) is True
-        assert await store.is_allowed(20) is True
+        assert await store.is_allowed(actor_id(20)) is True
         assert allow.replies[0].text == "AI access allowed."
         assert allow.deleted is True
 
@@ -166,7 +174,7 @@ async def test_unauthorized_and_revoked_users_are_silent(tmp_path):
         assert unauthorized.replies == []
         assert gateway.requests == []
 
-        await store.allow_user(20)
+        await store.allow_user(actor_id(20))
         target = FakeMessage("target", sender_id=20)
         deny = FakeMessage("/ai_deny", sender_id=10, reply_to=target)
         assert await handler.handle(deny) is True
@@ -190,7 +198,7 @@ async def test_nonowner_has_one_inflight_request_and_persistent_cooldown(tmp_pat
         gateway,
         clock=lambda: now[0],
     )
-    await store.allow_user(20)
+    await store.allow_user(actor_id(20))
     try:
         first = FakeMessage("/ai first", sender_id=20)
         first_task = asyncio.create_task(handler.handle(first))
@@ -219,18 +227,18 @@ async def test_nonowner_has_one_inflight_request_and_persistent_cooldown(tmp_pat
             cooldown_seconds=30,
             clock=lambda: restarted_now[0],
         )
-        assert await restarted.is_allowed(20) is True
-        assert await limiter.acquire(user_id=20, is_owner=False) is False
+        assert await restarted.is_allowed(actor_id(20)) is True
+        assert await limiter.acquire(actor_id=actor_id(20), is_owner=False) is False
         restarted_now[0] = 131.0
-        assert await limiter.acquire(user_id=20, is_owner=False) is True
-        await limiter.release(user_id=20, is_owner=False)
-        await restarted.deny_user(20)
+        assert await limiter.acquire(actor_id=actor_id(20), is_owner=False) is True
+        await limiter.release(actor_id=actor_id(20), is_owner=False)
+        await restarted.deny_user(actor_id(20))
     finally:
         await restarted.close()
 
     final_store = await AIStateRepository(tmp_path / "state.db").connect()
     try:
-        assert await final_store.is_allowed(20) is False
+        assert await final_store.is_allowed(actor_id(20)) is False
     finally:
         await final_store.close()
 
@@ -245,7 +253,7 @@ async def test_owner_is_exempt_and_never_added_to_whitelist(tmp_path):
         assert await handler.handle(allow_owner) is True
         assert allow_owner.replies[0].text == "Owner access is always enabled."
         assert allow_owner.deleted is True
-        assert await store.is_allowed(10) is False
+        assert await store.is_allowed(actor_id(10)) is False
 
         first = FakeMessage("/ai first", sender_id=10)
         second = FakeMessage("/ai second", sender_id=10)
@@ -274,7 +282,7 @@ async def test_nonowner_access_command_is_not_executed_or_deleted(tmp_path):
         assert await handler.handle(command) is False
         assert command.deleted is False
         assert command.replies == []
-        assert await store.is_allowed(30) is False
+        assert await store.is_allowed(actor_id(30)) is False
     finally:
         await store.close()
 

--- a/tests/test_ai_access.py
+++ b/tests/test_ai_access.py
@@ -114,7 +114,7 @@ async def make_handler(path, gateway, *, clock=lambda: 100.0, cooldown=30.0):
     limiter = AIRateLimiter(store, cooldown_seconds=cooldown, clock=clock)
     handler = AIConversationHandler(
         owner_id=10,
-        responder=AIResponder(gateway, edit_cadence=0),
+        responder=AIResponder(gateway),
         store=store,
         prompt_builder=PromptBuilder(),
         rate_limiter=limiter,

--- a/tests/test_ai_agent_runs.py
+++ b/tests/test_ai_agent_runs.py
@@ -14,6 +14,15 @@ from telefire.ai import (
     AgentRunRequest,
     PromptBuilder,
 )
+from telefire.telegram.ai_transport import TelegramChatTransport
+
+
+def make_telegram_responder(gateway, **kwargs):
+    return AIResponder(
+        gateway,
+        transport=TelegramChatTransport(edit_cadence=0),
+        **kwargs,
+    )
 
 
 class FakeAnswer:
@@ -186,7 +195,7 @@ async def test_tool_snapshot_is_replaced_by_the_streamed_final_answer():
                 answer="<b>Final answer</b>",
             )
 
-    responder = AIResponder(SnapshotGateway(), edit_cadence=0)
+    responder = make_telegram_responder(SnapshotGateway())
     trigger = FakeMessage("/ai search")
     request = AgentRunRequest(
         run_id="11111111-1111-4111-8111-111111111111",
@@ -244,7 +253,7 @@ async def test_repeated_tool_snapshot_does_not_fail_the_agent_run():
                 answer="Final answer",
             )
 
-    responder = AIResponder(ParallelSearchGateway(), edit_cadence=0)
+    responder = make_telegram_responder(ParallelSearchGateway())
     trigger = TelegramLikeMessage("/ai search")
     request = AgentRunRequest(
         run_id="11111111-1111-4111-8111-111111111111",
@@ -277,7 +286,7 @@ async def test_provider_rate_limit_gets_an_explicit_telegram_message():
                 message="Agent provider is temporarily rate limited",
             )
 
-    responder = AIResponder(RateLimitedGateway(), edit_cadence=0)
+    responder = make_telegram_responder(RateLimitedGateway())
     trigger = FakeMessage("/ai hello")
     request = AgentRunRequest(
         run_id="11111111-1111-4111-8111-111111111111",
@@ -303,7 +312,7 @@ async def test_handler_maps_answers_to_pi_sessions_and_forks_by_entry():
     store = FakeStore(allowed={20})
     handler = AIConversationHandler(
         owner_id=10,
-        responder=AIResponder(gateway, edit_cadence=0),
+        responder=make_telegram_responder(gateway),
         store=store,
         prompt_builder=PromptBuilder(),
     )
@@ -332,7 +341,7 @@ async def test_ai_cancel_aborts_only_the_requesters_active_run():
     store = FakeStore()
     handler = AIConversationHandler(
         owner_id=10,
-        responder=AIResponder(gateway, edit_cadence=0),
+        responder=make_telegram_responder(gateway),
         store=store,
         prompt_builder=PromptBuilder(),
     )

--- a/tests/test_ai_agent_runs.py
+++ b/tests/test_ai_agent_runs.py
@@ -14,6 +14,7 @@ from telefire.ai import (
     AgentRunRequest,
     PromptBuilder,
 )
+from telefire.telegram.ai_identity import TELEGRAM_IDENTITY_CODEC
 from telefire.telegram.ai_transport import TelegramChatTransport
 
 
@@ -127,19 +128,19 @@ class BlockingAgentGateway(FakeAgentGateway):
 
 
 class FakeStore:
-    def __init__(self, allowed: set[int] | None = None):
+    def __init__(self, allowed: set[str] | None = None):
         self.allowed = allowed or set()
-        self.markers: dict[tuple[int, int], AIAnswerMarker] = {}
+        self.markers: dict[tuple[str, int], AIAnswerMarker] = {}
 
-    async def get_answer(self, chat_id, answer_message_id):
-        return self.markers.get((chat_id, answer_message_id))
+    async def get_answer(self, scope_id, answer_message_id):
+        return self.markers.get((scope_id, answer_message_id))
 
-    async def get_turn_for_message(self, chat_id, message_id):
+    async def get_turn_for_message(self, scope_id, message_id):
         return next(
             (
                 marker
                 for marker in reversed(tuple(self.markers.values()))
-                if marker.chat_id == chat_id
+                if marker.scope_id == scope_id
                 and message_id
                 in {marker.answer_message_id, marker.trigger_message_id}
             ),
@@ -147,22 +148,22 @@ class FakeStore:
         )
 
     async def save_answer(self, marker):
-        self.markers[(marker.chat_id, marker.answer_message_id)] = marker
+        self.markers[(marker.scope_id, marker.answer_message_id)] = marker
 
-    async def is_allowed(self, user_id):
-        return user_id in self.allowed
+    async def is_allowed(self, actor_id):
+        return actor_id in self.allowed
 
-    async def get_last_request_at(self, user_id):
+    async def get_last_request_at(self, actor_id):
         return None
 
-    async def set_last_request_at(self, user_id, timestamp):
+    async def set_last_request_at(self, actor_id, timestamp):
         return None
 
-    async def allow_user(self, user_id):
-        self.allowed.add(user_id)
+    async def allow_user(self, actor_id):
+        self.allowed.add(actor_id)
 
-    async def deny_user(self, user_id):
-        self.allowed.discard(user_id)
+    async def deny_user(self, actor_id):
+        self.allowed.discard(actor_id)
 
 
 @pytest.fixture(autouse=True)
@@ -309,17 +310,20 @@ async def test_provider_rate_limit_gets_an_explicit_telegram_message():
 @pytest.mark.asyncio
 async def test_handler_maps_answers_to_pi_sessions_and_forks_by_entry():
     gateway = FakeAgentGateway(["root answer", "child answer", "fork answer"])
-    store = FakeStore(allowed={20})
+    store = FakeStore(allowed={TELEGRAM_IDENTITY_CODEC.actor_id(20)})
     handler = AIConversationHandler(
         owner_id=10,
         responder=make_telegram_responder(gateway),
         store=store,
-        prompt_builder=PromptBuilder(),
+        prompt_builder=PromptBuilder(identity_codec=TELEGRAM_IDENTITY_CODEC),
+        identity_codec=TELEGRAM_IDENTITY_CODEC,
     )
     root = FakeMessage("/ai root prompt", sender_id=20)
     await handler.handle(root)
     root_answer = root.replies[0]
-    root_marker = store.markers[(root.chat_id, root_answer.id)]
+    root_marker = store.markers[
+        (TELEGRAM_IDENTITY_CODEC.scope_id(root.chat_id), root_answer.id)
+    ]
 
     child = FakeMessage("child prompt", sender_id=20, reply_to=root_answer)
     await handler.handle(child)
@@ -343,7 +347,8 @@ async def test_ai_cancel_aborts_only_the_requesters_active_run():
         owner_id=10,
         responder=make_telegram_responder(gateway),
         store=store,
-        prompt_builder=PromptBuilder(),
+        prompt_builder=PromptBuilder(identity_codec=TELEGRAM_IDENTITY_CODEC),
+        identity_codec=TELEGRAM_IDENTITY_CODEC,
     )
     trigger = FakeMessage("/ai wait")
     running = asyncio.create_task(handler.handle(trigger))

--- a/tests/test_ai_conversations.py
+++ b/tests/test_ai_conversations.py
@@ -109,17 +109,17 @@ class FakeHistorySource:
 
 class FakeStore:
     def __init__(self):
-        self.markers: dict[tuple[int, int], AIAnswerMarker] = {}
+        self.markers: dict[tuple[str, int], AIAnswerMarker] = {}
 
-    async def get_answer(self, chat_id: int, answer_message_id: int):
-        return self.markers.get((chat_id, answer_message_id))
+    async def get_answer(self, scope_id: str, answer_message_id: int):
+        return self.markers.get((scope_id, answer_message_id))
 
-    async def get_turn_for_message(self, chat_id: int, message_id: int):
+    async def get_turn_for_message(self, scope_id: str, message_id: int):
         return next(
             (
                 marker
                 for marker in reversed(tuple(self.markers.values()))
-                if marker.chat_id == chat_id
+                if marker.scope_id == scope_id
                 and message_id
                 in {marker.answer_message_id, marker.trigger_message_id}
             ),
@@ -127,21 +127,21 @@ class FakeStore:
         )
 
     async def save_answer(self, marker: AIAnswerMarker):
-        self.markers[(marker.chat_id, marker.answer_message_id)] = marker
+        self.markers[(marker.scope_id, marker.answer_message_id)] = marker
 
-    async def is_allowed(self, user_id: int):
+    async def is_allowed(self, actor_id: str):
         return False
 
-    async def get_last_request_at(self, user_id: int):
+    async def get_last_request_at(self, actor_id: str):
         return None
 
-    async def set_last_request_at(self, user_id: int, timestamp: float):
+    async def set_last_request_at(self, actor_id: str, timestamp: float):
         return None
 
-    async def allow_user(self, user_id: int):
+    async def allow_user(self, actor_id: str):
         return None
 
-    async def deny_user(self, user_id: int):
+    async def deny_user(self, actor_id: str):
         return None
 
 
@@ -297,7 +297,9 @@ async def test_numbered_trigger_rejoins_nearest_ai_session():
 
     assert await handler.handle(rejoin) is True
 
-    root_marker = store.markers[(trigger.chat_id, first_answer.id)]
+    root_marker = store.markers[
+        (TELEGRAM_IDENTITY_CODEC.scope_id(trigger.chat_id), first_answer.id)
+    ]
     request = gateway.requests[1]
     assert request.session_id == root_marker.agent_session_id
     assert request.parent_entry_id == root_marker.agent_entry_id
@@ -367,11 +369,18 @@ async def test_direct_reply_to_ai_answer_continues_without_ai_command():
     follow_up = FakeMessage("Give me an example", reply_to=first_answer)
     assert await handler.handle(follow_up) is True
 
-    root_marker = store.markers[(trigger.chat_id, first_answer.id)]
+    root_marker = store.markers[
+        (TELEGRAM_IDENTITY_CODEC.scope_id(trigger.chat_id), first_answer.id)
+    ]
     assert gateway.requests[1].prompt == "Give me an example"
     assert gateway.requests[1].session_id == root_marker.agent_session_id
     assert gateway.requests[1].parent_entry_id == root_marker.agent_entry_id
-    second_marker = store.markers[(follow_up.chat_id, follow_up.replies[0].id)]
+    second_marker = store.markers[
+        (
+            TELEGRAM_IDENTITY_CODEC.scope_id(follow_up.chat_id),
+            follow_up.replies[0].id,
+        )
+    ]
     assert second_marker.parent_answer_message_id == first_answer.id
 
 
@@ -386,11 +395,18 @@ async def test_explicit_ai_reply_to_trigger_continues_completed_turn():
     follow_up = FakeMessage("/ai Give me an example", reply_to=trigger)
     assert await handler.handle(follow_up) is True
 
-    root_marker = store.markers[(trigger.chat_id, first_answer.id)]
+    root_marker = store.markers[
+        (TELEGRAM_IDENTITY_CODEC.scope_id(trigger.chat_id), first_answer.id)
+    ]
     assert gateway.requests[1].prompt == "Give me an example"
     assert gateway.requests[1].session_id == root_marker.agent_session_id
     assert gateway.requests[1].parent_entry_id == root_marker.agent_entry_id
-    second_marker = store.markers[(follow_up.chat_id, follow_up.replies[0].id)]
+    second_marker = store.markers[
+        (
+            TELEGRAM_IDENTITY_CODEC.scope_id(follow_up.chat_id),
+            follow_up.replies[0].id,
+        )
+    ]
     assert second_marker.parent_answer_message_id == first_answer.id
 
 
@@ -406,10 +422,17 @@ async def test_explicit_ai_deeper_in_reply_branch_uses_nearest_answer():
     rejoin = FakeMessage("/ai Compare both explanations", reply_to=human_branch)
     assert await handler.handle(rejoin) is True
 
-    root_marker = store.markers[(trigger.chat_id, first_answer.id)]
+    root_marker = store.markers[
+        (TELEGRAM_IDENTITY_CODEC.scope_id(trigger.chat_id), first_answer.id)
+    ]
     assert gateway.requests[1].session_id == root_marker.agent_session_id
     assert gateway.requests[1].parent_entry_id == root_marker.agent_entry_id
-    rejoin_marker = store.markers[(rejoin.chat_id, rejoin.replies[0].id)]
+    rejoin_marker = store.markers[
+        (
+            TELEGRAM_IDENTITY_CODEC.scope_id(rejoin.chat_id),
+            rejoin.replies[0].id,
+        )
+    ]
     assert rejoin_marker.parent_answer_message_id == first_answer.id
 
 
@@ -465,10 +488,10 @@ async def test_answer_marker_survives_repository_restart(tmp_path):
     path = tmp_path / "ai-state.db"
     first_store = await AIStateRepository(path).connect()
     marker = AIAnswerMarker(
-        chat_id=-1001,
+        scope_id=TELEGRAM_IDENTITY_CODEC.scope_id(-1001),
         answer_message_id=50,
         trigger_message_id=40,
-        requester_id=10,
+        requester_id=TELEGRAM_IDENTITY_CODEC.actor_id(10),
         prompt="persisted question",
         answer_text="persisted answer",
         parent_answer_message_id=None,
@@ -533,9 +556,10 @@ async def test_state_repository_migrates_pre_pi_answer_rows(tmp_path):
 
     store = await AIStateRepository(path).connect()
     try:
-        marker = await store.get_answer(-1001, 50)
-        turn_from_answer = await store.get_turn_for_message(-1001, 50)
-        turn_from_trigger = await store.get_turn_for_message(-1001, 40)
+        scope_id = TELEGRAM_IDENTITY_CODEC.scope_id(-1001)
+        marker = await store.get_answer(scope_id, 50)
+        turn_from_answer = await store.get_turn_for_message(scope_id, 50)
+        turn_from_trigger = await store.get_turn_for_message(scope_id, 40)
     finally:
         await store.close()
 

--- a/tests/test_ai_conversations.py
+++ b/tests/test_ai_conversations.py
@@ -149,7 +149,7 @@ def make_handler(gateway, store=None, **builder_options):
     return (
         AIConversationHandler(
             owner_id=10,
-            responder=AIResponder(gateway, edit_cadence=0),
+            responder=AIResponder(gateway),
             store=store,
             prompt_builder=PromptBuilder(**builder_options),
         ),

--- a/tests/test_ai_conversations.py
+++ b/tests/test_ai_conversations.py
@@ -158,6 +158,9 @@ def make_handler(gateway, store=None, **builder_options):
 
 
 class FakeAttachmentDescriber:
+    def has_attachment(self, message):
+        return message.file is not None
+
     async def describe(self, message):
         if message.file is None:
             return None

--- a/tests/test_ai_conversations.py
+++ b/tests/test_ai_conversations.py
@@ -15,6 +15,7 @@ from telefire.ai import (
     PromptBuilder,
 )
 from telefire.ai_attachments import AttachmentDescription
+from telefire.telegram.ai_identity import TELEGRAM_IDENTITY_CODEC
 
 
 class FakeAnswer:
@@ -151,7 +152,10 @@ def make_handler(gateway, store=None, **builder_options):
             owner_id=10,
             responder=AIResponder(gateway),
             store=store,
-            prompt_builder=PromptBuilder(**builder_options),
+            prompt_builder=PromptBuilder(
+                identity_codec=TELEGRAM_IDENTITY_CODEC,
+                **builder_options,
+            ),
         ),
         store,
     )

--- a/tests/test_ai_dream.py
+++ b/tests/test_ai_dream.py
@@ -288,6 +288,9 @@ class FakeAttachmentDescriber:
     def __init__(self):
         self.calls = []
 
+    def has_attachment(self, message):
+        return message.file is not None
+
     async def describe(self, message):
         self.calls.append(message.id)
         if message.file is None:

--- a/tests/test_ai_dream.py
+++ b/tests/test_ai_dream.py
@@ -9,7 +9,6 @@ from telethon.errors import FloodWaitError
 from telefire.ai import (
     AIAnswerMarker,
     AIStateRepository,
-    MemoryBackfillRequest,
     MessageIdentity,
     PromptBuilder,
 )
@@ -29,6 +28,7 @@ from telefire.ai_dream import (
 )
 from telefire.ai_attachments import AttachmentDescription
 from telefire.ai_memory import MemoryClientError, MemoryRetainResult
+from telefire.chat.commands import MemoryBackfillCommand
 
 
 NOW = datetime(2026, 7, 13, 12, 0, tzinfo=UTC)
@@ -1046,7 +1046,7 @@ async def test_days_backfill_uses_rolling_window_without_moving_dream_watermark(
     try:
         result = await scanner.run_backfill(
             -1001,
-            MemoryBackfillRequest(mode="days", value=7),
+            MemoryBackfillCommand(mode="days", value=7),
         )
 
         assert result.messages_seen == 1
@@ -1076,7 +1076,7 @@ async def test_message_backfill_works_while_disabled_and_is_idempotent(tmp_path)
     memory = FakeMemory()
     store, scanner = await make_scanner(tmp_path, source, memory)
     await store.set_dream_memory_enabled("telegram:chat:-1001", False)
-    request = MemoryBackfillRequest(mode="messages", value=2)
+    request = MemoryBackfillCommand(mode="messages", value=2)
     try:
         first_result = await scanner.run_backfill(-1001, request)
         second_result = await scanner.run_backfill(-1001, request)
@@ -1244,7 +1244,7 @@ async def test_days_backfill_rejects_a_window_above_its_separate_limit(tmp_path)
         with pytest.raises(DreamBackfillLimitError, match="5,000"):
             await scanner.run_backfill(
                 -1001,
-                MemoryBackfillRequest(mode="days", value=1),
+                MemoryBackfillCommand(mode="days", value=1),
             )
 
         assert memory.retain_calls == []
@@ -1871,7 +1871,7 @@ async def test_scope_timeout_includes_waiting_for_an_existing_operation(tmp_path
     backfill = asyncio.create_task(
         scanner.run_backfill(
             -1001,
-            MemoryBackfillRequest(mode="messages", value=1),
+            MemoryBackfillCommand(mode="messages", value=1),
         )
     )
     try:

--- a/tests/test_ai_dream.py
+++ b/tests/test_ai_dream.py
@@ -29,6 +29,10 @@ from telefire.ai_dream import (
 from telefire.ai_attachments import AttachmentDescription
 from telefire.ai_memory import MemoryClientError, MemoryRetainResult
 from telefire.chat.commands import MemoryBackfillCommand
+from telefire.telegram.ai_identity import (
+    TELEGRAM_IDENTITY_CODEC,
+    telegram_memory_event_metadata,
+)
 
 
 NOW = datetime(2026, 7, 13, 12, 0, tzinfo=UTC)
@@ -323,6 +327,8 @@ async def make_scanner(
         prompt_builder=PromptBuilder(
             identity_resolver=identity_resolver or FakeIdentityResolver(),
             attachment_describer=attachment_describer,
+            identity_codec=TELEGRAM_IDENTITY_CODEC,
+            metadata_resolver=telegram_memory_event_metadata,
         ),
         settings=DreamSettings(
             lookback=timedelta(hours=1),

--- a/tests/test_ai_dream.py
+++ b/tests/test_ai_dream.py
@@ -360,10 +360,10 @@ async def test_manual_dream_retains_standalone_and_complete_reply_tree(tmp_path)
     store, scanner = await make_scanner(tmp_path, source, memory)
     await store.save_answer(
         AIAnswerMarker(
-            chat_id=-1001,
+            scope_id=TELEGRAM_IDENTITY_CODEC.scope_id(-1001),
             answer_message_id=ai_answer.id,
             trigger_message_id=999,
-            requester_id=20,
+            requester_id=TELEGRAM_IDENTITY_CODEC.actor_id(20),
             prompt="old",
             answer_text=ai_answer.raw_text,
             parent_answer_message_id=None,
@@ -372,7 +372,11 @@ async def test_manual_dream_retains_standalone_and_complete_reply_tree(tmp_path)
             agent_entry_id="entry-old",
         )
     )
-    await store.mark_memory_excluded_message(-1001, control.id, "memory-control")
+    await store.mark_memory_excluded_message(
+        TELEGRAM_IDENTITY_CODEC.scope_id(-1001),
+        control.id,
+        "memory-control",
+    )
     try:
         result = await scanner.run_scope(-1001)
 
@@ -1162,7 +1166,11 @@ async def test_continuous_memory_skips_excluded_messages_without_stalling_cursor
         True,
         cursor_message_id=41,
     )
-    await store.mark_memory_excluded_message(-1001, 42, "memory-control")
+    await store.mark_memory_excluded_message(
+        TELEGRAM_IDENTITY_CODEC.scope_id(-1001),
+        42,
+        "memory-control",
+    )
     try:
         result = await scanner.run_continuous_scope(-1001)
 
@@ -1347,7 +1355,11 @@ async def test_dream_excludes_marked_messages_bots_and_keeps_attachment_text(tmp
         memory,
         attachment_describer=FakeAttachmentDescriber(),
     )
-    await store.mark_memory_excluded_message(-1001, excluded.id, "memory-control")
+    await store.mark_memory_excluded_message(
+        TELEGRAM_IDENTITY_CODEC.scope_id(-1001),
+        excluded.id,
+        "memory-control",
+    )
     try:
         result = await scanner.run_scope(-1001)
 

--- a/tests/test_ai_memory_integration.py
+++ b/tests/test_ai_memory_integration.py
@@ -381,6 +381,9 @@ class FakeAttachmentDescriber:
     def __init__(self, descriptions=None):
         self.descriptions = descriptions or {}
 
+    def has_attachment(self, message):
+        return message.id in self.descriptions
+
     async def describe(self, message):
         return self.descriptions.get(message.id)
 

--- a/tests/test_ai_memory_integration.py
+++ b/tests/test_ai_memory_integration.py
@@ -156,15 +156,15 @@ class FakeStore:
         self.memory_labels = {}
         self.memory_scope_display_names = {}
 
-    async def get_answer(self, chat_id, answer_message_id):
-        return self.markers.get((chat_id, answer_message_id))
+    async def get_answer(self, scope_id, answer_message_id):
+        return self.markers.get((scope_id, answer_message_id))
 
-    async def get_turn_for_message(self, chat_id, message_id):
+    async def get_turn_for_message(self, scope_id, message_id):
         return next(
             (
                 marker
                 for marker in reversed(tuple(self.markers.values()))
-                if marker.chat_id == chat_id
+                if marker.scope_id == scope_id
                 and message_id
                 in {marker.answer_message_id, marker.trigger_message_id}
             ),
@@ -172,22 +172,22 @@ class FakeStore:
         )
 
     async def save_answer(self, marker):
-        self.markers[(marker.chat_id, marker.answer_message_id)] = marker
+        self.markers[(marker.scope_id, marker.answer_message_id)] = marker
 
-    async def is_allowed(self, user_id):
-        return user_id in self.allowed
+    async def is_allowed(self, actor_id):
+        return actor_id in self.allowed
 
-    async def allow_user(self, user_id):
-        self.allowed.add(user_id)
+    async def allow_user(self, actor_id):
+        self.allowed.add(actor_id)
 
-    async def deny_user(self, user_id):
-        self.allowed.discard(user_id)
+    async def deny_user(self, actor_id):
+        self.allowed.discard(actor_id)
 
-    async def get_last_request_at(self, user_id):
-        return self.last_request.get(user_id)
+    async def get_last_request_at(self, actor_id):
+        return self.last_request.get(actor_id)
 
-    async def set_last_request_at(self, user_id, timestamp):
-        self.last_request[user_id] = timestamp
+    async def set_last_request_at(self, actor_id, timestamp):
+        self.last_request[actor_id] = timestamp
 
     async def get_memory_document_receipt(self, scope_id, document_id):
         return self.memory_documents.get((scope_id, document_id))
@@ -283,11 +283,13 @@ class FakeStore:
         if display_name:
             self.memory_scope_display_names[scope_id] = display_name
 
-    async def mark_memory_excluded_message(self, chat_id, message_id, kind):
-        self.memory_excluded.add((chat_id, message_id, kind))
+    async def mark_memory_excluded_message(self, scope_id, message_id, kind):
+        self.memory_excluded.add((scope_id, message_id, kind))
 
-    async def is_memory_excluded_message(self, chat_id, message_id):
-        return any(item[:2] == (chat_id, message_id) for item in self.memory_excluded)
+    async def is_memory_excluded_message(self, scope_id, message_id):
+        return any(
+            item[:2] == (scope_id, message_id) for item in self.memory_excluded
+        )
 
     async def get_memory_dream_state(self, scope_id):
         return self.memory_dream_state.get(scope_id, MemoryDreamState(scope_id))
@@ -846,11 +848,12 @@ async def test_ai_generated_chain_message_is_context_but_not_retained_evidence()
     human = FakeMessage("I prefer Rust", sender_id=20)
     ai_output = FakeMessage("Generated claim", sender_id=10, reply_to=human)
     store = FakeStore()
-    store.markers[(ai_output.chat_id, ai_output.id)] = AIAnswerMarker(
-        chat_id=ai_output.chat_id,
+    scope_id = TELEGRAM_IDENTITY_CODEC.scope_id(ai_output.chat_id)
+    store.markers[(scope_id, ai_output.id)] = AIAnswerMarker(
+        scope_id=scope_id,
         answer_message_id=ai_output.id,
         trigger_message_id=999,
-        requester_id=20,
+        requester_id=TELEGRAM_IDENTITY_CODEC.actor_id(20),
         prompt="old prompt",
         answer_text=ai_output.raw_text,
         parent_answer_message_id=None,
@@ -1026,14 +1029,15 @@ async def test_revision_does_not_curate_when_correction_evidence_fails():
 @pytest.mark.asyncio
 async def test_revision_requires_direct_human_target_and_owner():
     memory = FakeMemory()
-    store = FakeStore(allowed={20})
+    store = FakeStore(allowed={TELEGRAM_IDENTITY_CODEC.actor_id(20)})
     human = FakeMessage("I prefer Rust", sender_id=20)
     ai_output = FakeMessage("Generated answer", sender_id=10, reply_to=human)
-    store.markers[(ai_output.chat_id, ai_output.id)] = AIAnswerMarker(
-        chat_id=ai_output.chat_id,
+    scope_id = TELEGRAM_IDENTITY_CODEC.scope_id(ai_output.chat_id)
+    store.markers[(scope_id, ai_output.id)] = AIAnswerMarker(
+        scope_id=scope_id,
         answer_message_id=ai_output.id,
         trigger_message_id=999,
-        requester_id=20,
+        requester_id=TELEGRAM_IDENTITY_CODEC.actor_id(20),
         prompt="question",
         answer_text=ai_output.raw_text,
         parent_answer_message_id=None,
@@ -1602,7 +1606,7 @@ async def test_continuous_scope_skips_duplicate_ai_reply_chain_retain():
 
 @pytest.mark.asyncio
 async def test_enabled_scope_does_not_retain_non_human_ai_request():
-    store = FakeStore(allowed={20})
+    store = FakeStore(allowed={TELEGRAM_IDENTITY_CODEC.actor_id(20)})
     memory = FakeMemory()
     handler = make_handler(
         FakeGateway(["answer"]),
@@ -1630,7 +1634,7 @@ async def test_failed_agent_run_does_not_retain_enabled_scope():
 
 @pytest.mark.asyncio
 async def test_non_owner_cannot_change_scope_memory_state():
-    store = FakeStore(allowed={20})
+    store = FakeStore(allowed={TELEGRAM_IDENTITY_CODEC.actor_id(20)})
     resolver = FakeMemoryScopeResolver()
     handler = make_handler(
         FakeGateway(["unused"]),
@@ -1674,10 +1678,10 @@ async def test_outgoing_channel_post_can_enable_continuous_memory():
 
 @pytest.mark.asyncio
 async def test_post_answer_retain_does_not_hold_delegated_rate_lease():
-    store = FakeStore(allowed={20})
+    store = FakeStore(allowed={TELEGRAM_IDENTITY_CODEC.actor_id(20)})
     memory = BlockingRetainMemory()
     gateway = FakeGateway(["first answer", "second answer"])
-    handler = make_handler(gateway, memory, store=store, allowed={20})
+    handler = make_handler(gateway, memory, store=store)
 
     first = FakeMessage("/ai first", sender_id=20)
     first_task = asyncio.create_task(handler.handle(first))
@@ -1927,7 +1931,7 @@ async def test_invalid_and_non_owner_backfill_commands_do_not_start_work():
     handler = make_handler(
         FakeGateway(["unused"]),
         FakeMemory(),
-        store=FakeStore(allowed={20}),
+        store=FakeStore(allowed={TELEGRAM_IDENTITY_CODEC.actor_id(20)}),
         dream_runner=runner,
     )
     invalid = FakeMessage("/ai_memory_backfill days 31", sender_id=10)

--- a/tests/test_ai_memory_integration.py
+++ b/tests/test_ai_memory_integration.py
@@ -17,7 +17,6 @@ from telefire.ai import (
     AgentRunRequest,
     MessageIdentity,
     MentionedUser,
-    MemoryBackfillRequest,
     MemoryDreamResult,
     MemoryDreamState,
     MemoryScopeState,
@@ -37,6 +36,7 @@ from telefire.ai_memory import (
     MemoryRevisionResult,
     RecalledMemory,
 )
+from telefire.chat.commands import MemoryBackfillCommand
 
 
 class FakeAnswer:
@@ -1276,7 +1276,7 @@ async def test_owner_can_enable_continuous_memory_for_remote_channel():
     store = FakeStore()
     resolver = FakeMemoryScopeResolver(
         {
-            -1002064685671: MemoryScopeTarget(
+            "-1002064685671": MemoryScopeTarget(
                 chat_id=-1002064685671,
                 display_name="Seele Leaks",
                 latest_message_id=33392,
@@ -1298,7 +1298,7 @@ async def test_owner_can_enable_continuous_memory_for_remote_channel():
     assert await handler.handle(command) is True
 
     scope_id = "telegram:chat:-1002064685671"
-    assert resolver.calls == [(-1002064685671, True)]
+    assert resolver.calls == [("-1002064685671", True)]
     assert scope_id in store.memory_continuous
     assert store.memory_continuous_cursors[scope_id] == 33392
     assert store.memory_scope_display_names[scope_id] == "Seele Leaks"
@@ -1316,7 +1316,7 @@ async def test_owner_can_disable_continuous_memory_for_remote_channel():
     store.memory_continuous.add(scope_id)
     resolver = FakeMemoryScopeResolver(
         {
-            -1002064685671: MemoryScopeTarget(
+            "-1002064685671": MemoryScopeTarget(
                 chat_id=-1002064685671,
                 display_name="Seele Leaks",
             )
@@ -1336,7 +1336,7 @@ async def test_owner_can_disable_continuous_memory_for_remote_channel():
 
     assert await handler.handle(command) is True
 
-    assert resolver.calls == [(-1002064685671, False)]
+    assert resolver.calls == [("-1002064685671", False)]
     assert scope_id not in store.memory_continuous
     assert command.deleted is True
     assert command.replies[0].text == (
@@ -1358,7 +1358,7 @@ async def test_owner_can_control_dream_for_remote_channel(command_text, enabled)
     store.memory_dream.add(scope_id)
     resolver = FakeMemoryScopeResolver(
         {
-            -1002064685671: MemoryScopeTarget(
+            "-1002064685671": MemoryScopeTarget(
                 chat_id=-1002064685671,
                 display_name="Seele Leaks",
             )
@@ -1374,42 +1374,58 @@ async def test_owner_can_control_dream_for_remote_channel(command_text, enabled)
 
     assert await handler.handle(command) is True
 
-    assert resolver.calls == [(-1002064685671, False)]
+    assert resolver.calls == [("-1002064685671", False)]
     assert (scope_id in store.memory_dream) is enabled
     assert command.deleted is True
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("command_text", "expected"),
-    [
-        (
-            "/ai_memory_enable not-an-id",
-            "Usage: /ai_memory_enable [numeric group/channel ID]",
-        ),
-        (
-            "/ai_dream_enable -1001 extra",
-            "Usage: /ai_dream_enable [numeric group/channel ID]",
-        ),
-    ],
-)
-async def test_remote_memory_commands_reject_invalid_target_syntax(
-    command_text,
-    expected,
-):
+async def test_remote_memory_commands_reject_extra_arguments():
     resolver = FakeMemoryScopeResolver()
     handler = make_handler(
         FakeGateway(["unused"]),
         FakeMemory(),
         memory_scope_resolver=resolver,
     )
-    command = FakeMessage(command_text, sender_id=10)
+    command = FakeMessage("/ai_dream_enable -1001 extra", sender_id=10)
 
     assert await handler.handle(command) is True
 
     assert resolver.calls == []
     assert command.deleted is False
-    assert command.replies[0].text == expected
+    assert command.replies[0].text == (
+        "Usage: /ai_dream_enable [chat target]"
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_memory_command_passes_opaque_target_to_adapter():
+    resolver = FakeMemoryScopeResolver(
+        {
+            "seele-leaks": MemoryScopeTarget(
+                chat_id=-1002064685671,
+                display_name="Seele Leaks",
+                latest_message_id=33392,
+            )
+        }
+    )
+    handler = make_handler(
+        FakeGateway(["unused"]),
+        FakeMemory(),
+        memory_scope_resolver=resolver,
+    )
+    command = FakeMessage(
+        "/ai_memory_enable seele-leaks",
+        sender_id=10,
+        chat_id=10,
+    )
+
+    assert await handler.handle(command) is True
+
+    assert resolver.calls == [("seele-leaks", True)]
+    assert command.replies[0].text.startswith(
+        "Continuous memory enabled for Seele Leaks"
+    )
 
 
 @pytest.mark.asyncio
@@ -1430,8 +1446,8 @@ async def test_remote_memory_command_reports_inaccessible_target():
 
     assert command.deleted is False
     assert command.replies[0].text == (
-        "Unable to access that Telegram group/channel. "
-        "Check the numeric chat ID and this account's access."
+        "Unable to access that chat target. "
+        "Check its identifier and this account's access."
     )
 
 
@@ -1862,12 +1878,12 @@ async def test_failed_manual_dream_deletes_command_but_keeps_error_visible():
     [
         (
             "/ai_memory_backfill days 7",
-            MemoryBackfillRequest(mode="days", value=7),
+            MemoryBackfillCommand(mode="days", value=7),
             "Backfilling the last 7 days...",
         ),
         (
             "/ai_memory_backfill messages 500",
-            MemoryBackfillRequest(mode="messages", value=500),
+            MemoryBackfillCommand(mode="messages", value=500),
             "Backfilling the latest 500 messages...",
         ),
     ],

--- a/tests/test_ai_memory_integration.py
+++ b/tests/test_ai_memory_integration.py
@@ -488,7 +488,7 @@ def make_handler(
     store = store or FakeStore(allowed=allowed)
     return AIConversationHandler(
         owner_id=10,
-        responder=AIResponder(gateway, edit_cadence=0),
+        responder=AIResponder(gateway),
         store=store,
         prompt_builder=PromptBuilder(
             attachment_describer=attachment_describer,

--- a/tests/test_ai_memory_integration.py
+++ b/tests/test_ai_memory_integration.py
@@ -22,8 +22,6 @@ from telefire.ai import (
     MemoryScopeState,
     MemoryScopeTarget,
     PromptBuilder,
-    TelegramMessageIdentityResolver,
-    TelegramMessageMentionResolver,
 )
 from telefire.ai_attachments import AttachmentDescription
 from telefire.ai_memory import (
@@ -37,6 +35,12 @@ from telefire.ai_memory import (
     RecalledMemory,
 )
 from telefire.chat.commands import MemoryBackfillCommand
+from telefire.telegram.ai_identity import (
+    TELEGRAM_IDENTITY_CODEC,
+    TelegramMessageIdentityResolver,
+    TelegramMessageMentionResolver,
+    telegram_memory_event_metadata,
+)
 
 
 class FakeAnswer:
@@ -495,12 +499,15 @@ def make_handler(
             identity_resolver=identity_resolver,
             mention_resolver=mention_resolver,
             history_source=history_source,
+            identity_codec=TELEGRAM_IDENTITY_CODEC,
+            metadata_resolver=telegram_memory_event_metadata,
         ),
         rate_limiter=AIRateLimiter(store, cooldown_seconds=0),
         memory=memory,
         dream_runner=dream_runner,
         memory_scope_resolver=memory_scope_resolver,
         memory_command_delete_delay=memory_command_delete_delay,
+        identity_codec=TELEGRAM_IDENTITY_CODEC,
         logger=logger,
     )
 

--- a/tests/test_ai_plugin.py
+++ b/tests/test_ai_plugin.py
@@ -9,9 +9,9 @@ from telethon.tl import types as telegram_types
 from telefire.ai import MemoryScopeTarget
 from telefire.plugins.ai import (
     TelegramAI,
-    TelegramMemoryScopeTargetResolver,
     _parse_telegram_message_link,
 )
+from telefire.telegram.ai_identity import TelegramMemoryScopeTargetResolver
 
 
 class FailingHandler:

--- a/tests/test_ai_plugin.py
+++ b/tests/test_ai_plugin.py
@@ -279,7 +279,7 @@ async def test_memory_scope_target_resolver_resolves_channel_and_latest_message(
     resolver = TelegramMemoryScopeTargetResolver(client)
 
     target = await resolver.resolve(
-        -1002064685671,
+        "-1002064685671",
         include_latest_message=True,
     )
 
@@ -299,7 +299,7 @@ async def test_memory_scope_target_resolver_rejects_users():
     resolver = TelegramMemoryScopeTargetResolver(client)
 
     with pytest.raises(ValueError, match="group or channel"):
-        await resolver.resolve(20)
+        await resolver.resolve("20")
 
     assert client.get_messages_calls == []
 

--- a/tests/test_ai_streaming.py
+++ b/tests/test_ai_streaming.py
@@ -19,6 +19,11 @@ from telefire.ai import (
     parse_memory_revision,
 )
 from telefire.plugins.base import command_registry
+from telefire.telegram.ai_transport import (
+    TelegramChatTransport,
+    select_telegram_response_format,
+    telegram_system_prompt,
+)
 import telefire.plugins.ai  # noqa: F401
 
 
@@ -82,6 +87,27 @@ class FakeGateway:
 
     async def cancel(self, run_id: str) -> bool:
         return True
+
+
+def make_telegram_responder(
+    gateway,
+    *,
+    edit_cadence=0,
+    clock=None,
+    response_format="regular_html",
+    **kwargs,
+):
+    transport_kwargs = {"edit_cadence": edit_cadence}
+    if clock is not None:
+        transport_kwargs["clock"] = clock
+    return AIResponder(
+        gateway,
+        transport=TelegramChatTransport(
+            response_format=response_format,
+            **transport_kwargs,
+        ),
+        **kwargs,
+    )
 
 
 class FakeStore:
@@ -233,7 +259,11 @@ def test_ai_command_is_registered_under_telegram():
 async def test_owner_gets_one_progressively_edited_answer():
     gateway = FakeGateway(["Hello", " ", "world"])
     times = iter([0.0, 1.0, 2.0, 3.0])
-    responder = AIResponder(gateway, edit_cadence=0.5, clock=lambda: next(times))
+    responder = make_telegram_responder(
+        gateway,
+        edit_cadence=0.5,
+        clock=lambda: next(times),
+    )
     handler = make_handler(owner_id=10, responder=responder)
     trigger = FakeMessage("/ai greet me")
 
@@ -257,9 +287,16 @@ async def test_edit_cadence_is_shared_across_answers(monkeypatch):
     async def fake_sleep(seconds):
         sleeps.append(seconds)
 
-    monkeypatch.setattr("telefire.ai.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr(
+        "telefire.telegram.ai_transport.asyncio.sleep",
+        fake_sleep,
+    )
     gateway = FakeGateway(["answer"])
-    responder = AIResponder(gateway, edit_cadence=4, clock=lambda: 0.0)
+    responder = make_telegram_responder(
+        gateway,
+        edit_cadence=4,
+        clock=lambda: 0.0,
+    )
     first = FakeMessage("/ai first")
     second = FakeMessage("/ai second")
 
@@ -295,8 +332,11 @@ async def test_flood_wait_delays_final_edit_without_replacing_the_answer(monkeyp
             self.replies.append(answer)
             return answer
 
-    monkeypatch.setattr("telefire.ai.asyncio.sleep", fake_sleep)
-    responder = AIResponder(
+    monkeypatch.setattr(
+        "telefire.telegram.ai_transport.asyncio.sleep",
+        fake_sleep,
+    )
+    responder = make_telegram_responder(
         FakeGateway(["final answer"]),
         edit_cadence=0,
         clock=lambda: 0.0,
@@ -312,7 +352,9 @@ async def test_flood_wait_delays_final_edit_without_replacing_the_answer(monkeyp
 
 
 def test_prompt_builder_appends_the_regular_telegram_format_guard():
-    builder = PromptBuilder(system_prompt="Keep answers factual.")
+    builder = PromptBuilder(
+        system_prompt=telegram_system_prompt("Keep answers factual.")
+    )
 
     assert builder.system_prompt.startswith("Keep answers factual.")
     assert "Telegram regular-message HTML" in builder.system_prompt
@@ -324,8 +366,6 @@ def test_prompt_builder_appends_the_regular_telegram_format_guard():
 
 
 def test_response_format_switches_only_for_a_bot_rich_transport():
-    from telefire.ai import select_telegram_response_format
-
     assert (
         select_telegram_response_format(
             is_bot_account=False,
@@ -349,8 +389,10 @@ def test_response_format_switches_only_for_a_bot_rich_transport():
     )
 
     rich_builder = PromptBuilder(
-        system_prompt="Keep answers factual.",
-        response_format="rich_markdown",
+        system_prompt=telegram_system_prompt(
+            "Keep answers factual.",
+            "rich_markdown",
+        ),
     )
     assert "Telegram Bot API rich-message Markdown" in rich_builder.system_prompt
     assert "| Header 1 | Header 2 |" in rich_builder.system_prompt
@@ -381,7 +423,7 @@ async def test_bot_response_uses_telegram_rich_markdown_edit():
 
     formatted = "**Result**\n\n| Key | Value |\n|:----|:------|\n| Mode | Rich |"
     gateway = FakeGateway([formatted])
-    responder = AIResponder(
+    responder = make_telegram_responder(
         gateway,
         edit_cadence=0,
         response_format="rich_markdown",
@@ -408,7 +450,7 @@ async def test_streamed_html_is_sent_as_native_telegram_entities():
         "<pre>Team     Score\nNorway   1\nEngland  2</pre>"
     )
     gateway = FakeGateway([formatted])
-    responder = AIResponder(gateway, edit_cadence=0)
+    responder = make_telegram_responder(gateway)
     trigger = FakeMessage("/ai format this")
 
     result = await responder.answer(trigger, make_request("format this"))
@@ -431,7 +473,7 @@ async def test_streamed_html_is_sent_as_native_telegram_entities():
 @pytest.mark.asyncio
 async def test_streaming_waits_for_visible_text_when_an_html_tag_is_split():
     gateway = FakeGateway(["<b>", "Result", "</b>"])
-    responder = AIResponder(gateway, edit_cadence=0)
+    responder = make_telegram_responder(gateway)
     trigger = FakeMessage("/ai format this")
 
     result = await responder.answer(trigger, make_request("format this"))
@@ -451,7 +493,7 @@ async def test_unauthorized_trigger_is_silent_and_does_not_call_provider():
     gateway = FakeGateway(["must not be used"])
     handler = make_handler(
         owner_id=10,
-        responder=AIResponder(gateway, edit_cadence=0),
+        responder=make_telegram_responder(gateway),
     )
     trigger = FakeMessage("/ai secret", sender_id=11)
 
@@ -465,7 +507,7 @@ async def test_owner_ai_requests_are_not_blocked_by_chat_scope():
     gateway = FakeGateway(["answer"])
     handler = AIConversationHandler(
         owner_id=10,
-        responder=AIResponder(gateway, edit_cadence=0),
+        responder=make_telegram_responder(gateway),
         store=FakeStore(),
         prompt_builder=PromptBuilder(),
     )
@@ -482,7 +524,7 @@ async def test_empty_prompt_finishes_with_usage_without_calling_provider():
     gateway = FakeGateway(["must not be used"])
     handler = make_handler(
         owner_id=10,
-        responder=AIResponder(gateway, edit_cadence=0),
+        responder=make_telegram_responder(gateway),
     )
     trigger = FakeMessage("/ai")
 
@@ -497,7 +539,7 @@ async def test_provider_failure_replaces_loading_message():
     gateway = FakeGateway(error=RuntimeError("provider secret detail"))
     handler = make_handler(
         owner_id=10,
-        responder=AIResponder(gateway, edit_cadence=0),
+        responder=make_telegram_responder(gateway),
     )
     trigger = FakeMessage("/ai hello")
 
@@ -512,9 +554,8 @@ async def test_provider_failure_uses_standard_logging_format(caplog):
     import logging
 
     gateway = FakeGateway(error=RuntimeError("provider detail"))
-    responder = AIResponder(
+    responder = make_telegram_responder(
         gateway,
-        edit_cadence=0,
         logger=logging.getLogger("telefire-ai-test"),
     )
     trigger = FakeMessage("/ai hello")
@@ -527,7 +568,7 @@ async def test_provider_failure_uses_standard_logging_format(caplog):
 @pytest.mark.asyncio
 async def test_output_is_bounded_and_finalized():
     gateway = FakeGateway(["abcdefghijk"])
-    responder = AIResponder(gateway, edit_cadence=0, max_output_chars=10)
+    responder = make_telegram_responder(gateway, max_output_chars=10)
     trigger = FakeMessage("/ai long")
 
     await responder.answer(trigger, make_request("long"))

--- a/tests/test_ai_streaming.py
+++ b/tests/test_ai_streaming.py
@@ -9,14 +9,16 @@ from telefire.ai import (
     AIConversationHandler,
     AIResponder,
     AISettings,
-    AITrigger,
     AgentEvent,
     AgentRunRequest,
-    MemoryBackfillRequest,
     PromptBuilder,
-    parse_ai_trigger,
-    parse_memory_backfill,
-    parse_memory_revision,
+)
+from telefire.chat.commands import (
+    AIAskCommand,
+    InvalidCommand,
+    MemoryBackfillCommand,
+    MemoryRememberCommand,
+    parse_chat_command,
 )
 from telefire.plugins.base import command_registry
 from telefire.telegram.ai_transport import (
@@ -172,37 +174,46 @@ def make_request(prompt: str) -> AgentRunRequest:
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("/ai hello", AITrigger(prompt="hello")),
-        ("/ai\nhello", AITrigger(prompt="hello")),
-        ("/ai", AITrigger(prompt="")),
-        ("/ai10 hello", AITrigger(prompt="hello", recent_messages=10)),
+        ("/ai hello", AIAskCommand(prompt="hello")),
+        ("/ai\nhello", AIAskCommand(prompt="hello")),
+        ("/ai", AIAskCommand(prompt="")),
+        ("/ai10 hello", AIAskCommand(prompt="hello", recent_messages=10)),
         (
             "/ai10@TelefireBot summarize this",
-            AITrigger(prompt="summarize this", recent_messages=10),
+            AIAskCommand(prompt="summarize this", recent_messages=10),
         ),
-        ("/ai0 invalid", AITrigger(prompt="invalid", recent_messages=0)),
+        ("/ai0 invalid", AIAskCommand(prompt="invalid", recent_messages=0)),
         (" /ai hello", None),
         ("/air hello", None),
         ("/ai10x hello", None),
-        ("/ai_memory hello", None),
+        (
+            "/ai_memory hello",
+            MemoryRememberCommand(instruction="hello"),
+        ),
         ("hello /ai", None),
     ],
 )
 def test_parse_ai_trigger_has_an_exact_command_boundary(text, expected):
-    assert parse_ai_trigger(text) == expected
+    assert parse_chat_command(text) == expected
 
 
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("/ai_memory remember this", "remember this"),
-        ("/ai_memory\nforget that", "forget that"),
-        ("/ai_memory", ""),
+        (
+            "/ai_memory remember this",
+            MemoryRememberCommand(instruction="remember this"),
+        ),
+        (
+            "/ai_memory\nforget that",
+            MemoryRememberCommand(instruction="forget that"),
+        ),
+        ("/ai_memory", MemoryRememberCommand(instruction="")),
         ("/ai_memoryx no", None),
     ],
 )
 def test_parse_memory_revision_has_an_exact_command_boundary(text, expected):
-    assert parse_memory_revision(text) == expected
+    assert parse_chat_command(text) == expected
 
 
 @pytest.mark.parametrize(
@@ -210,22 +221,37 @@ def test_parse_memory_revision_has_an_exact_command_boundary(text, expected):
     [
         (
             "/ai_memory_backfill days 7",
-            MemoryBackfillRequest(mode="days", value=7),
+            MemoryBackfillCommand(mode="days", value=7),
         ),
         (
             "/ai_memory_backfill\nmessages\t500",
-            MemoryBackfillRequest(mode="messages", value=500),
+            MemoryBackfillCommand(mode="messages", value=500),
         ),
-        ("/ai_memory_backfill days 0", None),
-        ("/ai_memory_backfill days 31", None),
-        ("/ai_memory_backfill messages 5001", None),
-        ("/ai_memory_backfill weeks 2", None),
-        ("/ai_memory_backfill days 7 extra", None),
+        (
+            "/ai_memory_backfill days 0",
+            InvalidCommand(name="/ai_memory_backfill"),
+        ),
+        (
+            "/ai_memory_backfill days 31",
+            InvalidCommand(name="/ai_memory_backfill"),
+        ),
+        (
+            "/ai_memory_backfill messages 5001",
+            InvalidCommand(name="/ai_memory_backfill"),
+        ),
+        (
+            "/ai_memory_backfill weeks 2",
+            InvalidCommand(name="/ai_memory_backfill"),
+        ),
+        (
+            "/ai_memory_backfill days 7 extra",
+            InvalidCommand(name="/ai_memory_backfill"),
+        ),
         ("/ai_memory_backfillx days 7", None),
     ],
 )
 def test_parse_memory_backfill_has_bounded_exact_syntax(text, expected):
-    assert parse_memory_backfill(text) == expected
+    assert parse_chat_command(text) == expected
 
 
 def test_ai_settings_are_loaded_without_provider_specific_assumptions(monkeypatch):

--- a/tests/test_ai_streaming.py
+++ b/tests/test_ai_streaming.py
@@ -21,6 +21,7 @@ from telefire.chat.commands import (
     parse_chat_command,
 )
 from telefire.plugins.base import command_registry
+from telefire.telegram.ai_identity import TELEGRAM_IDENTITY_CODEC
 from telefire.telegram.ai_transport import (
     TelegramChatTransport,
     select_telegram_response_format,
@@ -116,15 +117,15 @@ class FakeStore:
     def __init__(self):
         self.saved = []
 
-    async def get_answer(self, chat_id, answer_message_id):
+    async def get_answer(self, scope_id, answer_message_id):
         return None
 
-    async def get_turn_for_message(self, chat_id, message_id):
+    async def get_turn_for_message(self, scope_id, message_id):
         return next(
             (
                 marker
                 for marker in reversed(self.saved)
-                if marker.chat_id == chat_id
+                if marker.scope_id == scope_id
                 and message_id
                 in {marker.answer_message_id, marker.trigger_message_id}
             ),
@@ -134,19 +135,19 @@ class FakeStore:
     async def save_answer(self, marker):
         self.saved.append(marker)
 
-    async def is_allowed(self, user_id):
+    async def is_allowed(self, actor_id):
         return False
 
-    async def get_last_request_at(self, user_id):
+    async def get_last_request_at(self, actor_id):
         return None
 
-    async def set_last_request_at(self, user_id, timestamp):
+    async def set_last_request_at(self, actor_id, timestamp):
         return None
 
-    async def allow_user(self, user_id):
+    async def allow_user(self, actor_id):
         return None
 
-    async def deny_user(self, user_id):
+    async def deny_user(self, actor_id):
         return None
 
 
@@ -155,7 +156,8 @@ def make_handler(owner_id, responder):
         owner_id=owner_id,
         responder=responder,
         store=FakeStore(),
-        prompt_builder=PromptBuilder(),
+        prompt_builder=PromptBuilder(identity_codec=TELEGRAM_IDENTITY_CODEC),
+        identity_codec=TELEGRAM_IDENTITY_CODEC,
     )
 
 
@@ -535,7 +537,8 @@ async def test_owner_ai_requests_are_not_blocked_by_chat_scope():
         owner_id=10,
         responder=make_telegram_responder(gateway),
         store=FakeStore(),
-        prompt_builder=PromptBuilder(),
+        prompt_builder=PromptBuilder(identity_codec=TELEGRAM_IDENTITY_CODEC),
+        identity_codec=TELEGRAM_IDENTITY_CODEC,
     )
     trigger = FakeMessage("/ai secret")
     trigger.chat_id = -1002

--- a/tests/test_chat_core.py
+++ b/tests/test_chat_core.py
@@ -4,12 +4,14 @@ import ast
 from collections.abc import AsyncIterator
 from dataclasses import fields
 from pathlib import Path
+import sqlite3
 
 import pytest
 
 from telefire.ai import (
     AIConversationHandler,
     AIResponder,
+    AIStateRepository,
     AgentEvent,
     AgentRunRequest,
     MemoryScopeState,
@@ -209,31 +211,31 @@ class FakeStore:
     def __init__(self):
         self.saved = []
 
-    async def get_answer(self, chat_id, answer_message_id):
+    async def get_answer(self, scope_id, answer_message_id):
         return None
 
-    async def get_turn_for_message(self, chat_id, message_id):
+    async def get_turn_for_message(self, scope_id, message_id):
         return None
 
     async def save_answer(self, marker):
         self.saved.append(marker)
 
-    async def is_allowed(self, user_id):
+    async def is_allowed(self, actor_id):
         return False
 
-    async def get_last_request_at(self, user_id):
+    async def get_last_request_at(self, actor_id):
         return None
 
-    async def set_last_request_at(self, user_id, timestamp):
+    async def set_last_request_at(self, actor_id, timestamp):
         return None
 
-    async def allow_user(self, user_id):
+    async def allow_user(self, actor_id):
         return None
 
-    async def deny_user(self, user_id):
+    async def deny_user(self, actor_id):
         return None
 
-    async def mark_memory_excluded_message(self, chat_id, message_id, kind):
+    async def mark_memory_excluded_message(self, scope_id, message_id, kind):
         return None
 
     async def get_memory_scope_state(self, scope_id):
@@ -296,7 +298,7 @@ async def test_attachment_detection_does_not_require_telegram_file_attributes():
     assert transport.updates[-1] == ("final", "agent", True)
 
 
-def test_shared_ai_module_has_no_telethon_imports():
+def test_shared_ai_module_has_no_telegram_adapter_imports():
     import telefire.ai as ai_module
 
     tree = ast.parse(Path(ai_module.__file__).read_text())
@@ -312,7 +314,13 @@ def test_shared_ai_module_has_no_telethon_imports():
         if isinstance(node, ast.ImportFrom)
     )
 
-    assert not any(name == "telethon" or name.startswith("telethon.") for name in imported)
+    assert not any(
+        name == "telethon"
+        or name.startswith("telethon.")
+        or name == "telefire.telegram"
+        or name.startswith("telefire.telegram.")
+        for name in imported
+    )
 
 
 @pytest.mark.asyncio
@@ -328,10 +336,11 @@ async def test_memory_coordinates_follow_the_injected_chat_identity_codec():
         transport=transport,
         identity_codec=qq,
     )
+    store = FakeStore()
     handler = AIConversationHandler(
         owner_id=42,
         responder=AIResponder(gateway, transport=transport),
-        store=FakeStore(),
+        store=store,
         prompt_builder=prompt_builder,
         transport=transport,
         memory=object(),
@@ -345,3 +354,68 @@ async def test_memory_coordinates_follow_the_injected_chat_identity_codec():
     assert memory is not None
     assert memory.scope_id == "qq:group:7"
     assert [anchor.identity for anchor in memory.anchors] == ["qq:user:42"]
+    assert store.saved[0].scope_id == "qq:group:7"
+    assert store.saved[0].requester_id == "qq:user:42"
+
+
+@pytest.mark.asyncio
+async def test_state_repository_migrates_legacy_telegram_identity_columns(tmp_path):
+    path = tmp_path / "ai.db"
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE ai_answers (
+            chat_id INTEGER NOT NULL,
+            answer_message_id INTEGER NOT NULL,
+            trigger_message_id INTEGER NOT NULL,
+            requester_id INTEGER NOT NULL,
+            prompt TEXT NOT NULL,
+            answer_text TEXT NOT NULL,
+            parent_answer_message_id INTEGER,
+            reference_context TEXT NOT NULL,
+            agent_session_id TEXT,
+            agent_entry_id TEXT,
+            PRIMARY KEY (chat_id, answer_message_id)
+        );
+        INSERT INTO ai_answers VALUES (
+            -1001, 100, 1, 20, 'question', 'answer', NULL, '', 's1', 'e1'
+        );
+        CREATE TABLE ai_whitelist (
+            user_id INTEGER PRIMARY KEY,
+            allowed_at REAL NOT NULL
+        );
+        INSERT INTO ai_whitelist VALUES (20, 1);
+        CREATE TABLE ai_usage (
+            user_id INTEGER PRIMARY KEY,
+            last_request_at REAL NOT NULL
+        );
+        INSERT INTO ai_usage VALUES (20, 2);
+        CREATE TABLE ai_memory_excluded_messages (
+            chat_id INTEGER NOT NULL,
+            message_id INTEGER NOT NULL,
+            kind TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            PRIMARY KEY (chat_id, message_id)
+        );
+        INSERT INTO ai_memory_excluded_messages VALUES (-1001, 101, 'ai-answer', 3);
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    store = await AIStateRepository(path).connect()
+    try:
+        marker = await store.get_answer("telegram:chat:-1001", 100)
+
+        assert marker is not None
+        assert marker.scope_id == "telegram:chat:-1001"
+        assert marker.requester_id == "telegram:user:20"
+        assert await store.is_allowed("telegram:user:20") is True
+        assert await store.is_allowed("qq:user:20") is False
+        assert await store.get_last_request_at("telegram:user:20") == 2
+        assert await store.is_memory_excluded_message(
+            "telegram:chat:-1001",
+            101,
+        )
+    finally:
+        await store.close()

--- a/tests/test_chat_core.py
+++ b/tests/test_chat_core.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import fields
+
+import pytest
+
+from telefire.ai import (
+    AIResponder,
+    AgentEvent,
+    AgentRunRequest,
+)
+from telefire.chat.attachments import AttachmentReference
+from telefire.chat.commands import (
+    AIAskCommand,
+    AICancelCommand,
+    AccessCommand,
+    InvalidCommand,
+    MemoryBackfillCommand,
+    MemoryModeCommand,
+    MemoryRememberCommand,
+    MemoryStatusCommand,
+    parse_chat_command,
+)
+from telefire.chat.identity import NamespacedIdentityCodec
+from telefire.chat.transport import ChatPresentation
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("/ai hello", AIAskCommand(prompt="hello")),
+        ("/ai10 hello", AIAskCommand(prompt="hello", recent_messages=10)),
+        (
+            "/ai10@TelefireBot summarize",
+            AIAskCommand(prompt="summarize", recent_messages=10),
+        ),
+        ("/ai_cancel", AICancelCommand()),
+        ("/ai_allow", AccessCommand(allowed=True)),
+        ("/ai_deny", AccessCommand(allowed=False)),
+        (
+            "/ai_memory remember this",
+            MemoryRememberCommand(instruction="remember this"),
+        ),
+        (
+            "/ai_memory_backfill messages 500",
+            MemoryBackfillCommand(mode="messages", value=500),
+        ),
+        (
+            "/ai_memory_enable qq-group-alias",
+            MemoryModeCommand(
+                mode="continuous",
+                enabled=True,
+                target="qq-group-alias",
+            ),
+        ),
+        ("/ai_memory_status", MemoryStatusCommand()),
+        (
+            "/ai_memory_backfill days 31",
+            InvalidCommand(name="/ai_memory_backfill"),
+        ),
+    ],
+)
+def test_chat_commands_are_parsed_without_transport_assumptions(text, expected):
+    assert parse_chat_command(text) == expected
+
+
+def test_identity_codec_keeps_network_identities_disjoint():
+    telegram = NamespacedIdentityCodec(
+        source="telegram",
+        actor_kind="user",
+        scope_kind="chat",
+    )
+    qq = NamespacedIdentityCodec(
+        source="qq",
+        actor_kind="user",
+        scope_kind="group",
+    )
+
+    assert telegram.actor_id(42) == "telegram:user:42"
+    assert qq.actor_id(42) == "qq:user:42"
+    assert telegram.scope_id(7) == "telegram:chat:7"
+    assert qq.scope_id(7) == "qq:group:7"
+    assert qq.message_source_id(7, 9) == "qq:message:7:9"
+    assert qq.thread_document_id(7, 9) == "qq:thread:7:9"
+    assert qq.revision_document_id(7, 9) == "qq:revision:7:9"
+
+
+def test_attachment_reference_contains_metadata_but_no_binary_payload():
+    reference = AttachmentReference(
+        key="onebot11:self-1:message-2:image-0",
+        kind="image",
+        mime_type="image/jpeg",
+        filename="photo.jpg",
+        size_bytes=1234,
+    )
+
+    assert reference.size_bytes == 1234
+    assert "data" not in {item.name for item in fields(reference)}
+    assert "content" not in {item.name for item in fields(reference)}
+    assert not any(
+        isinstance(getattr(reference, item.name), bytes) for item in fields(reference)
+    )
+
+
+class FakeGateway:
+    async def run(self, request: AgentRunRequest) -> AsyncIterator[AgentEvent]:
+        yield AgentEvent(
+            type="run_started",
+            run_id=request.run_id,
+            session_id="session-1",
+        )
+        yield AgentEvent(type="text_delta", delta="partial", reset=True)
+        yield AgentEvent(
+            type="run_completed",
+            session_id="session-1",
+            entry_id="entry-1",
+            answer="final",
+        )
+
+    async def cancel(self, run_id: str) -> bool:
+        return True
+
+
+class FakeSentMessage:
+    def __init__(self):
+        self.id = 100
+        self.text = "Thinking..."
+
+
+class FakeTransport:
+    def __init__(self):
+        self.sent = FakeSentMessage()
+        self.updates: list[tuple[str, ChatPresentation, bool]] = []
+
+    async def get_reply(self, message):
+        return None
+
+    async def reply(self, message, text, *, presentation):
+        assert presentation == "plain"
+        self.sent.text = text
+        return self.sent
+
+    async def update(self, message, text, *, presentation, wait):
+        self.updates.append((text, presentation, wait))
+        self.sent.text = text
+        return True
+
+    async def delete(self, message):
+        return None
+
+    def is_outgoing(self, message):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_responder_streams_through_transport_not_message_sdk_methods():
+    transport = FakeTransport()
+    responder = AIResponder(FakeGateway(), transport=transport)
+    trigger = object()
+    request = AgentRunRequest(
+        run_id="run-1",
+        session_id=None,
+        parent_entry_id=None,
+        prompt="question",
+        context=(),
+        system_prompt="system",
+        tool_policy="owner",
+    )
+
+    result = await responder.answer(trigger, request)
+
+    assert result.succeeded is True
+    assert result.message is transport.sent
+    assert transport.updates[-1] == ("final", "agent", True)

--- a/tests/test_chat_core.py
+++ b/tests/test_chat_core.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import ast
 from collections.abc import AsyncIterator
 from dataclasses import fields
+from pathlib import Path
 
 import pytest
 
@@ -10,6 +12,7 @@ from telefire.ai import (
     AIResponder,
     AgentEvent,
     AgentRunRequest,
+    MemoryScopeState,
     PromptBuilder,
 )
 from telefire.chat.attachments import AttachmentDescription, AttachmentReference
@@ -106,7 +109,11 @@ def test_attachment_reference_contains_metadata_but_no_binary_payload():
 
 
 class FakeGateway:
+    def __init__(self):
+        self.requests: list[AgentRunRequest] = []
+
     async def run(self, request: AgentRunRequest) -> AsyncIterator[AgentEvent]:
+        self.requests.append(request)
         yield AgentEvent(
             type="run_started",
             run_id=request.run_id,
@@ -229,6 +236,12 @@ class FakeStore:
     async def mark_memory_excluded_message(self, chat_id, message_id, kind):
         return None
 
+    async def get_memory_scope_state(self, scope_id):
+        return MemoryScopeState(
+            scope_id=scope_id,
+            continuous_enabled=True,
+        )
+
 
 @pytest.mark.asyncio
 async def test_handler_uses_transport_for_sdk_operations():
@@ -281,3 +294,54 @@ async def test_attachment_detection_does_not_require_telegram_file_attributes():
 
     assert handled is True
     assert transport.updates[-1] == ("final", "agent", True)
+
+
+def test_shared_ai_module_has_no_telethon_imports():
+    import telefire.ai as ai_module
+
+    tree = ast.parse(Path(ai_module.__file__).read_text())
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported.update(
+        node.module or ""
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+    )
+
+    assert not any(name == "telethon" or name.startswith("telethon.") for name in imported)
+
+
+@pytest.mark.asyncio
+async def test_memory_coordinates_follow_the_injected_chat_identity_codec():
+    transport = FakeTransport()
+    gateway = FakeGateway()
+    qq = NamespacedIdentityCodec(
+        source="qq",
+        actor_kind="user",
+        scope_kind="group",
+    )
+    prompt_builder = PromptBuilder(
+        transport=transport,
+        identity_codec=qq,
+    )
+    handler = AIConversationHandler(
+        owner_id=42,
+        responder=AIResponder(gateway, transport=transport),
+        store=FakeStore(),
+        prompt_builder=prompt_builder,
+        transport=transport,
+        memory=object(),
+        identity_codec=qq,
+    )
+    message = MinimalMessage("/ai who am I?")
+
+    assert await handler.handle(message) is True
+
+    memory = gateway.requests[0].memory
+    assert memory is not None
+    assert memory.scope_id == "qq:group:7"
+    assert [anchor.identity for anchor in memory.anchors] == ["qq:user:42"]

--- a/tests/test_chat_core.py
+++ b/tests/test_chat_core.py
@@ -6,11 +6,13 @@ from dataclasses import fields
 import pytest
 
 from telefire.ai import (
+    AIConversationHandler,
     AIResponder,
     AgentEvent,
     AgentRunRequest,
+    PromptBuilder,
 )
-from telefire.chat.attachments import AttachmentReference
+from telefire.chat.attachments import AttachmentDescription, AttachmentReference
 from telefire.chat.commands import (
     AIAskCommand,
     AICancelCommand,
@@ -132,12 +134,15 @@ class FakeTransport:
     def __init__(self):
         self.sent = FakeSentMessage()
         self.updates: list[tuple[str, ChatPresentation, bool]] = []
+        self.replies: list[tuple[object, str, ChatPresentation]] = []
+        self.reply_targets: dict[object, object] = {}
+        self.deleted: list[object] = []
 
     async def get_reply(self, message):
-        return None
+        return self.reply_targets.get(message)
 
     async def reply(self, message, text, *, presentation):
-        assert presentation == "plain"
+        self.replies.append((message, text, presentation))
         self.sent.text = text
         return self.sent
 
@@ -147,7 +152,7 @@ class FakeTransport:
         return True
 
     async def delete(self, message):
-        return None
+        self.deleted.append(message)
 
     def is_outgoing(self, message):
         return False
@@ -172,4 +177,107 @@ async def test_responder_streams_through_transport_not_message_sdk_methods():
 
     assert result.succeeded is True
     assert result.message is transport.sent
+    assert transport.updates[-1] == ("final", "agent", True)
+
+
+class MinimalMessage:
+    def __init__(
+        self,
+        text: str,
+        *,
+        message_id: int = 1,
+        chat_id: int = 7,
+        sender_id: int = 42,
+        reply_to_message_id: int | None = None,
+    ):
+        self.id = message_id
+        self.chat_id = chat_id
+        self.sender_id = sender_id
+        self.raw_text = text
+        self.reply_to_msg_id = reply_to_message_id
+        self.date = None
+
+
+class FakeStore:
+    def __init__(self):
+        self.saved = []
+
+    async def get_answer(self, chat_id, answer_message_id):
+        return None
+
+    async def get_turn_for_message(self, chat_id, message_id):
+        return None
+
+    async def save_answer(self, marker):
+        self.saved.append(marker)
+
+    async def is_allowed(self, user_id):
+        return False
+
+    async def get_last_request_at(self, user_id):
+        return None
+
+    async def set_last_request_at(self, user_id, timestamp):
+        return None
+
+    async def allow_user(self, user_id):
+        return None
+
+    async def deny_user(self, user_id):
+        return None
+
+    async def mark_memory_excluded_message(self, chat_id, message_id, kind):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_handler_uses_transport_for_sdk_operations():
+    transport = FakeTransport()
+    gateway = FakeGateway()
+    handler = AIConversationHandler(
+        owner_id=42,
+        responder=AIResponder(gateway, transport=transport),
+        store=FakeStore(),
+        prompt_builder=PromptBuilder(transport=transport),
+        transport=transport,
+    )
+    message = MinimalMessage("/ai question")
+
+    handled = await handler.handle(message)
+
+    assert handled is True
+    assert transport.replies[0] == (message, "Thinking...", "plain")
+    assert transport.updates[-1] == ("final", "agent", True)
+
+
+class OpaqueAttachmentDescriber:
+    def has_attachment(self, message):
+        return True
+
+    async def describe(self, message):
+        return AttachmentDescription(
+            context_text="Generated image description",
+            memory_text="The subject shared an image.",
+        )
+
+
+@pytest.mark.asyncio
+async def test_attachment_detection_does_not_require_telegram_file_attributes():
+    transport = FakeTransport()
+    gateway = FakeGateway()
+    handler = AIConversationHandler(
+        owner_id=42,
+        responder=AIResponder(gateway, transport=transport),
+        store=FakeStore(),
+        prompt_builder=PromptBuilder(
+            transport=transport,
+            attachment_describer=OpaqueAttachmentDescriber(),
+        ),
+        transport=transport,
+    )
+    message = MinimalMessage("/ai")
+
+    handled = await handler.handle(message)
+
+    assert handled is True
     assert transport.updates[-1] == ("final", "agent", True)


### PR DESCRIPTION
## Summary
- extract typed AI and memory command parsing into a chat-neutral module
- route replies, edits, deletes, identity resolution, mentions, and formatting through injected adapter contracts
- move Telegram formatting, rate limiting, identity metadata, and scope resolution into Telegram modules
- namespace authorization, rate-limit, answer, and exclusion state so Telegram and future OneBot identities cannot collide
- keep attachment payload bytes inside bounded client adapters; shared contracts carry metadata/descriptions only

## OneBot 11 integration boundary
A OneBot adapter now only needs normalized message data, a `ChatTransport`, an identity codec, optional history/mention/attachment resolvers, and a memory scope resolver. Since OneBot 11 has no standard message-edit action, its transport can ignore non-final updates and replace/delete the placeholder when `wait=True`.

This PR does not add the OneBot network connector itself.

## Migration
Existing pre-namespaced SQLite rows are migrated once to `telegram:*` actor and scope IDs during repository startup.

## Verification
- `uv run pytest -q` (265 passed, 6 skipped)
- `uv run python -m compileall -q src tests`
- `git diff --check origin/master...HEAD`
- reviewed for adapter dependency direction, SQL parameterization, identity collisions, and binary payload leakage