### PR TITLE
Fix memory command acknowledgement threading

### DIFF
--- a/src/telefire/ai.py
+++ b/src/telefire/ai.py
@@ -2720,8 +2720,8 @@ class AIConversationHandler:
                 response = f"Dream enabled for {destination}."
             else:
                 response = f"Dream disabled for {destination}."
-        await self._schedule_memory_command_delete(message, command.name)
         await self._reply_memory_excluded(message, response, kind="memory-control")
+        await self._schedule_memory_command_delete(message, command.name)
         return True
 
     async def _handle_memory_scope_status(self, message: ReplyTarget) -> bool:
@@ -2754,14 +2754,14 @@ class AIConversationHandler:
                 f"Last Dream error: {state.last_error or 'none'}",
             )
         )
-        await self._schedule_memory_command_delete(
-            message,
-            "/ai_memory_status",
-        )
         await self._reply_memory_excluded(
             message,
             response,
             kind="memory-control",
+        )
+        await self._schedule_memory_command_delete(
+            message,
+            "/ai_memory_status",
         )
         return True
 
@@ -2781,12 +2781,12 @@ class AIConversationHandler:
                 lines.append(line)
                 response_length += len(line) + 1
             response = "\n".join((header, *lines))
-        await self._schedule_memory_command_delete(message, "/ai_memory_list")
         await self._reply_memory_excluded(
             message,
             response,
             kind="memory-control",
         )
+        await self._schedule_memory_command_delete(message, "/ai_memory_list")
         return True
 
     async def _continuous_memory_enabled(self, chat_id: int) -> bool:
@@ -2801,49 +2801,38 @@ class AIConversationHandler:
 
     async def _handle_memory_dream(self, message: ReplyTarget) -> bool:
         assert message.chat_id is not None
-        await self._schedule_memory_command_delete(message, "/ai_memory_dream")
         scope = await self._store.get_memory_scope_state(
             self._identity_codec.scope_id(message.chat_id)
         )
         if scope.continuous_enabled:
-            await self._reply_memory_excluded(
-                message,
-                "Continuous memory is enabled; Dream is currently overridden.",
-                kind="memory-control",
+            response = (
+                "Continuous memory is enabled; Dream is currently overridden."
             )
-            return True
-        if not scope.dream_enabled:
-            await self._reply_memory_excluded(
-                message,
-                "Dream is disabled for this chat.",
-                kind="memory-control",
-            )
-            return True
-        if self._dream_runner is None:
-            await self._reply_memory_excluded(
-                message,
-                "Dream Cycle is unavailable.",
-                kind="memory-control",
-            )
-            return True
-        try:
-            result = await self._dream_runner.run_scope(message.chat_id)
-        except Exception as exc:
-            self._log_memory_failure("Dream Cycle", exc)
-            await self._reply_memory_excluded(
-                message,
-                "Dream Cycle failed. It will retry from the previous cursor.",
-                kind="memory-control",
-            )
-            return True
+        elif not scope.dream_enabled:
+            response = "Dream is disabled for this chat."
+        elif self._dream_runner is None:
+            response = "Dream Cycle is unavailable."
+        else:
+            try:
+                result = await self._dream_runner.run_scope(message.chat_id)
+            except Exception as exc:
+                self._log_memory_failure("Dream Cycle", exc)
+                response = (
+                    "Dream Cycle failed. It will retry from the previous cursor."
+                )
+            else:
+                response = (
+                    "Dream Cycle complete: "
+                    f"{_pluralize(result.messages_retained, 'message')} in "
+                    f"{_pluralize(result.documents_created, 'updated thread')}; "
+                    f"{result.documents_unchanged} unchanged."
+                )
         await self._reply_memory_excluded(
             message,
-            "Dream Cycle complete: "
-            f"{_pluralize(result.messages_retained, 'message')} in "
-            f"{_pluralize(result.documents_created, 'updated thread')}; "
-            f"{result.documents_unchanged} unchanged.",
+            response,
             kind="memory-control",
         )
+        await self._schedule_memory_command_delete(message, "/ai_memory_dream")
         return True
 
     async def _handle_memory_backfill(
@@ -2852,12 +2841,15 @@ class AIConversationHandler:
         request: MemoryBackfillCommand,
     ) -> bool:
         assert message.chat_id is not None
-        await self._schedule_memory_command_delete(message, "/ai_memory_backfill")
         if self._dream_runner is None:
             await self._reply_memory_excluded(
                 message,
                 "Memory backfill is unavailable.",
                 kind="memory-control",
+            )
+            await self._schedule_memory_command_delete(
+                message,
+                "/ai_memory_backfill",
             )
             return True
         if request.mode == "days":
@@ -2869,6 +2861,7 @@ class AIConversationHandler:
             progress_text,
             kind="memory-control",
         )
+        await self._schedule_memory_command_delete(message, "/ai_memory_backfill")
         try:
             result = await self._dream_runner.run_backfill(message.chat_id, request)
         except Exception as exc:
@@ -3062,7 +3055,6 @@ class AIConversationHandler:
             )
             return True
 
-        await self._schedule_memory_command_delete(message, "/ai_memory")
         retained = await self._retain_memory_chain(target)
         if retained is None:
             await self._reply_memory_excluded(
@@ -3070,6 +3062,7 @@ class AIConversationHandler:
                 "Memory update failed. Retry the command.",
                 kind="memory-control",
             )
+            await self._schedule_memory_command_delete(message, "/ai_memory")
             return True
         observations = retained.observations
         if not instruction and not observations:
@@ -3078,6 +3071,7 @@ class AIConversationHandler:
                 "The reply chain has no supported human content to remember.",
                 kind="memory-control",
             )
+            await self._schedule_memory_command_delete(message, "/ai_memory")
             return True
 
         if instruction:
@@ -3118,6 +3112,7 @@ class AIConversationHandler:
                     "Memory revision failed. Retry the command.",
                     kind="memory-control",
                 )
+                await self._schedule_memory_command_delete(message, "/ai_memory")
                 return True
             try:
                 await self._memory.revise(
@@ -3132,6 +3127,7 @@ class AIConversationHandler:
                     "Memory revision failed. Retry the command.",
                     kind="memory-control",
                 )
+                await self._schedule_memory_command_delete(message, "/ai_memory")
                 return True
 
         if instruction:
@@ -3148,6 +3144,7 @@ class AIConversationHandler:
             response,
             kind="memory-control",
         )
+        await self._schedule_memory_command_delete(message, "/ai_memory")
         return True
 
     async def _retain_memory_chain(

--- a/tests/test_ai_memory_integration.py
+++ b/tests/test_ai_memory_integration.py
@@ -1986,7 +1986,7 @@ async def test_memory_status_command_is_deleted_after_configured_delay():
 
 
 @pytest.mark.asyncio
-async def test_memory_dream_command_deletes_while_scan_is_still_running():
+async def test_memory_dream_command_deletes_after_scan_acknowledgement():
     class BlockingDreamRunner(FakeDreamRunner):
         def __init__(self):
             super().__init__()
@@ -2020,8 +2020,42 @@ async def test_memory_dream_command_deletes_while_scan_is_still_running():
     await runner.started.wait()
     await asyncio.sleep(0.02)
 
-    assert command.deleted is True
+    assert command.deleted is False
     assert run.done() is False
 
     runner.release.set()
     assert await run is True
+    assert command.replies[0].text.startswith("Dream Cycle complete:")
+    assert command.deleted is False
+
+    await asyncio.sleep(0.02)
+
+    assert command.deleted is True
+
+
+@pytest.mark.asyncio
+async def test_memory_command_deletes_after_retain_acknowledgement():
+    memory = BlockingRetainMemory()
+    handler = make_handler(
+        FakeGateway(["unused"]),
+        memory,
+        memory_command_delete_delay=0.01,
+    )
+    target = FakeMessage("I prefer tea", sender_id=20)
+    command = FakeMessage("/ai_memory", sender_id=10, reply_to=target)
+
+    run = asyncio.create_task(handler.handle(command))
+    await memory.retain_started.wait()
+    await asyncio.sleep(0.02)
+
+    assert command.deleted is False
+    assert run.done() is False
+
+    memory.release_retain.set()
+    assert await run is True
+    assert command.replies[0].text == "Memory stored from reply chain: 1 message."
+    assert command.deleted is False
+
+    await asyncio.sleep(0.02)
+
+    assert command.deleted is True


### PR DESCRIPTION
## Summary
- keep stealth memory commands present until their acknowledgement or progress reply exists
- start the deletion delay only after Telegram can attach the reply to the command
- add regression coverage for long-running retain and Dream operations

## Verification
- `uv run pytest -q` (266 passed, 6 skipped)
- `uv run ruff check src/telefire/ai.py tests/test_ai_memory_integration.py`
- `git diff --check`

## Live reproduction
A deployed `/ai_memory` retain took longer than the 3-second deletion delay. Telegram deleted the command before the acknowledgement was sent, so the acknowledgement appeared as a detached message. This change enforces reply-before-delete ordering.
