### PR TITLE
Retry uncited Hindsight revision selection

### DIFF
--- a/src/telefire/ai_memory.py
+++ b/src/telefire/ai_memory.py
@@ -423,49 +423,59 @@ class HindsightMemoryClient:
         subject_id: str,
         instruction: str,
     ) -> MemoryRevisionResult:
-        selection = await self._request(
-            "POST",
-            self._bank_path(scope_id, "/reflect"),
-            {
-                "query": self._revision_query(
-                    subject_id=subject_id,
-                    instruction=instruction,
-                ),
-                "budget": "mid",
-                "max_tokens": 1_500,
-                "fact_types": ["world", "experience"],
-                "include": {"facts": {"max_tokens": 2_000}},
-                "response_schema": {
-                    "type": "object",
-                    "properties": {
-                        "invalidate_memory_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        }
-                    },
-                    "required": ["invalidate_memory_ids"],
-                    "additionalProperties": False,
-                },
-            },
+        query = self._revision_query(
+            subject_id=subject_id,
+            instruction=instruction,
         )
-        structured = selection.get("structured_output")
-        based_on = selection.get("based_on")
-        if not isinstance(structured, dict) or not isinstance(based_on, dict):
-            raise MemoryClientError("Hindsight revision response is malformed")
-        candidate_ids = structured.get("invalidate_memory_ids")
-        cited = based_on.get("memories")
-        if not isinstance(candidate_ids, list) or not all(
-            isinstance(memory_id, str) for memory_id in candidate_ids
-        ):
-            raise MemoryClientError("Hindsight revision response is malformed")
-        if not isinstance(cited, list):
-            raise MemoryClientError("Hindsight revision response is malformed")
-        cited_ids = {
-            item.get("id")
-            for item in cited
-            if isinstance(item, dict) and isinstance(item.get("id"), str)
-        }
-        if not set(candidate_ids) <= cited_ids:
+        for attempt in range(2):
+            if attempt:
+                query += (
+                    "\nRetry requirement: Every returned memory ID must be copied "
+                    "verbatim from a memory consulted in this reflection so it appears "
+                    "in based_on.memories. Otherwise return an empty list."
+                )
+            selection = await self._request(
+                "POST",
+                self._bank_path(scope_id, "/reflect"),
+                {
+                    "query": query,
+                    "budget": "mid",
+                    "max_tokens": 1_500,
+                    "fact_types": ["world", "experience"],
+                    "include": {"facts": {"max_tokens": 2_000}},
+                    "response_schema": {
+                        "type": "object",
+                        "properties": {
+                            "invalidate_memory_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            }
+                        },
+                        "required": ["invalidate_memory_ids"],
+                        "additionalProperties": False,
+                    },
+                },
+            )
+            structured = selection.get("structured_output")
+            based_on = selection.get("based_on")
+            if not isinstance(structured, dict) or not isinstance(based_on, dict):
+                raise MemoryClientError("Hindsight revision response is malformed")
+            candidate_ids = structured.get("invalidate_memory_ids")
+            cited = based_on.get("memories")
+            if not isinstance(candidate_ids, list) or not all(
+                isinstance(memory_id, str) for memory_id in candidate_ids
+            ):
+                raise MemoryClientError("Hindsight revision response is malformed")
+            if not isinstance(cited, list):
+                raise MemoryClientError("Hindsight revision response is malformed")
+            cited_ids = {
+                item.get("id")
+                for item in cited
+                if isinstance(item, dict) and isinstance(item.get("id"), str)
+            }
+            if set(candidate_ids) <= cited_ids:
+                break
+        else:
             raise MemoryClientError("Hindsight revision selected uncited memory")
 
         invalidated_count = 0

--- a/tests/test_ai_memory_client.py
+++ b/tests/test_ai_memory_client.py
@@ -353,9 +353,99 @@ async def test_hindsight_revision_invalidates_only_cited_target_memory():
 
 
 @pytest.mark.asyncio
-async def test_hindsight_revision_rejects_uncited_memory_selection():
+async def test_hindsight_revision_retries_uncited_selection_once():
+    received = {"reflect_calls": 0, "patch": []}
+
     async def reflect(request):
         await request.json()
+        received["reflect_calls"] += 1
+        if received["reflect_calls"] == 1:
+            return web.json_response(
+                {
+                    "text": "invalid",
+                    "structured_output": {
+                        "invalidate_memory_ids": ["invented-id"]
+                    },
+                    "based_on": {"memories": []},
+                }
+            )
+        return web.json_response(
+            {
+                "text": "The earlier tea preference conflicts.",
+                "structured_output": {
+                    "invalidate_memory_ids": ["memory-tea"]
+                },
+                "based_on": {
+                    "memories": [
+                        {
+                            "id": "memory-tea",
+                            "text": "Prefers tea",
+                            "type": "world",
+                        }
+                    ]
+                },
+            }
+        )
+
+    async def get_memory(request):
+        return web.json_response(
+            {
+                "id": request.match_info["memory_id"],
+                "type": "world",
+                "entities": ["telegram:user:20"],
+            }
+        )
+
+    async def patch_memory(request):
+        received["patch"].append(
+            (request.match_info["memory_id"], await request.json())
+        )
+        return web.json_response(
+            {"id": request.match_info["memory_id"], "state": "invalidated"}
+        )
+
+    def configure(app):
+        app.router.add_post("/v1/default/banks/{bank_id}/reflect", reflect)
+        app.router.add_get(
+            "/v1/default/banks/{bank_id}/memories/{memory_id}", get_memory
+        )
+        app.router.add_patch(
+            "/v1/default/banks/{bank_id}/memories/{memory_id}", patch_memory
+        )
+
+    runner, url = await start_server(configure)
+    client = HindsightMemoryClient(url)
+    try:
+        result = await client.revise(
+            scope_id="telegram:chat:-1001",
+            subject_id="telegram:user:20",
+            instruction="Correct the preference to coffee",
+        )
+
+        assert result == MemoryRevisionResult(invalidated_count=1)
+        assert received["reflect_calls"] == 2
+        assert received["patch"] == [
+            (
+                "memory-tea",
+                {
+                    "state": "invalidated",
+                    "reason": "Owner revision: Correct the preference to coffee",
+                },
+            )
+        ]
+    finally:
+        await client.close()
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_hindsight_revision_rejects_uncited_memory_selection():
+    reflect_calls = 0
+
+    async def reflect(request):
+        nonlocal reflect_calls
+        await request.json()
+        reflect_calls += 1
         return web.json_response(
             {
                 "text": "invalid",
@@ -376,6 +466,7 @@ async def test_hindsight_revision_rejects_uncited_memory_selection():
                 subject_id="telegram:user:20",
                 instruction="Forget tea",
             )
+        assert reflect_calls == 2
     finally:
         await client.close()
         await runner.cleanup()


### PR DESCRIPTION
## Summary
- retry Hindsight revision reflection once when it selects a memory absent from its own cited evidence
- strengthen the retry instruction so returned IDs must appear in `based_on.memories`
- preserve all existing scope, subject, memory-type, and cited-ID safety checks

## Verification
- `uv run pytest -q` (267 passed, 6 skipped)
- `uv run ruff check src/telefire/ai_memory.py tests/test_ai_memory_client.py`
- `git diff --check`

## Live reproduction
The deployed `/ai_memory <instruction>` command retained its correction evidence, but one Hindsight reflection returned an uncited candidate ID and was correctly rejected. Replaying the same reflection returned a valid cited ID, showing a bounded retry can recover nondeterministic model output without weakening invalidation safety.
