### PR TITLE
Fix Hindsight shared memory for index creation

### DIFF
--- a/memory/compose.yml
+++ b/memory/compose.yml
@@ -7,6 +7,8 @@ services:
         HINDSIGHT_CONTROL_PLANE_IMAGE: ${HINDSIGHT_CONTROL_PLANE_IMAGE:-telefire-hindsight-control-plane:0.8.4-bank-name.1}
     image: telefire-hindsight:0.8.4-bank-name.1-hardened-r1
     container_name: memory-api
+    # pg0 uses 512 MB maintenance_work_mem while creating vector indexes.
+    shm_size: 1gb
     environment:
       HINDSIGHT_API_LLM_PROVIDER: openai
       HINDSIGHT_API_LLM_API_KEY: ${MEMORY_LLM_API_KEY}


### PR DESCRIPTION
## Summary

- allocate 1 GiB of shared memory to the Hindsight container
- document why the embedded PostgreSQL index build needs more than Docker's default

## Root cause

The container inherited Docker's 64 MiB `/dev/shm` default while pg0 starts PostgreSQL with `maintenance_work_mem=512MB`. Creating a new bank's vector indexes therefore failed with a shared-memory allocation error.

## Verification

- reproduced six live Hindsight contract failures before the change
- resolved Compose config reports `shm_size: 1073741824`
- Compose dry-run scopes recreation to `memory-api` and preserves the named data volume
- `uv run pytest -q`: 298 passed, 6 skipped

After merge, `memory-api` will be recreated and the live Hindsight contract suite rerun before PR #34 is merged.
