### PR TITLE
fix(memory): stop leaking episode participants into every fact

### DIFF
--- a/src/telefire/ai_memory.py
+++ b/src/telefire/ai_memory.py
@@ -119,6 +119,18 @@ class MemoryEpisode:
         return tuple(actors)
 
     @property
+    def document_entity_ids(self) -> tuple[str, ...]:
+        # Hindsight associates top-level entities with every fact from a document.
+        if len(self.events) != 1:
+            return ()
+        event = self.events[0]
+        return tuple(
+            dict.fromkeys(
+                (event.actor_id, *(actor_id for actor_id, _ in event.mentioned_actors))
+            )
+        )
+
+    @property
     def event_versions(self) -> tuple[tuple[str, str], ...]:
         versions: list[tuple[str, str]] = []
         for index, event in enumerate(self.events):
@@ -731,7 +743,8 @@ class HindsightMemoryClient:
                 "content_hash": episode.content_hash,
             },
             "entities": [
-                {"text": actor_id, "type": "PERSON"} for actor_id in episode.actor_ids
+                {"text": actor_id, "type": "PERSON"}
+                for actor_id in episode.document_entity_ids
             ],
         }
 

--- a/tests/test_ai_memory_client.py
+++ b/tests/test_ai_memory_client.py
@@ -52,6 +52,19 @@ def episode() -> MemoryEpisode:
     )
 
 
+def test_document_entities_only_cover_a_single_event():
+    item = episode()
+
+    assert item.actor_ids == ("telegram:user:10", "telegram:user:20")
+    assert item.document_entity_ids == ()
+
+    single_event = replace(item, events=(item.events[1],))
+    assert single_event.document_entity_ids == (
+        "telegram:user:20",
+        "telegram:user:10",
+    )
+
+
 async def start_server(configure):
     app = web.Application()
     configure(app)
@@ -138,10 +151,7 @@ async def test_hindsight_client_retains_episode_and_renders_bank_recall():
         assert request_item["document_id"] == item.document_id
         assert request_item["update_mode"] == "replace"
         assert request_item["metadata"]["content_hash"] == item.content_hash
-        assert request_item["entities"] == [
-            {"text": "telegram:user:10", "type": "PERSON"},
-            {"text": "telegram:user:20", "type": "PERSON"},
-        ]
+        assert request_item["entities"] == []
         retained_content = json.loads(request_item["content"])
         assert retained_content["schema"] == "telefire.memory.episode.v1"
         assert retained_content["events"][1]["actor"] == {


### PR DESCRIPTION
## Summary
- distinguish episode participants from Hindsight document-level entities
- omit top-level entities for multi-event memory documents
- preserve author and explicit mentions for single-event memories

## Verification
- `uv run pytest -q` (331 passed, 8 skipped)
- live Hindsight dry-run attempted but extraction provider returned `503 auth_unavailable` for `gpt-5.6-sol`; the endpoint persisted nothing