### PR TITLE
Bind canonical entities to matching facts

### DIFF
--- a/memory/Dockerfile.hindsight
+++ b/memory/Dockerfile.hindsight
@@ -6,12 +6,14 @@ FROM ghcr.io/vectorize-io/hindsight:0.8.4@sha256:2c60f233eaba8f51db31adb920a5607
 USER root
 
 COPY patches/408d7c34-observation-history-fk-race.patch /tmp/
+COPY patches/conditional-entity-aliases.patch /tmp/
 
 RUN rm -rf /app/control-plane
 COPY --from=control-plane --chown=hindsight:hindsight /app/control-plane /app/control-plane
 
 LABEL io.telefire.hindsight.control-plane-source-revision="92f433c90409636804c0797071a4abbe141f76c5" \
-      io.telefire.hindsight.control-plane-patch="bee6f5d114c09a7bf51a2ef1d5357e0bdf0d9c2d"
+      io.telefire.hindsight.control-plane-patch="bee6f5d114c09a7bf51a2ef1d5357e0bdf0d9c2d" \
+      io.telefire.hindsight.fact-entity-hints="v1"
 
 # Hindsight runs from its bundled virtualenv and invokes Node directly. Remove
 # package managers left by the upstream build, apply available OS fixes, and
@@ -21,6 +23,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends patch \
     && patch --batch --forward -d /app/api -p1 \
         < /tmp/408d7c34-observation-history-fk-race.patch \
+    && patch --batch --forward -d /app/api -p1 \
+        < /tmp/conditional-entity-aliases.patch \
     && apt-get purge -y --auto-remove patch \
     && rm -rf \
         /app/sdk/node_modules/@hey-api/openapi-ts \
@@ -28,6 +32,7 @@ RUN apt-get update \
         /usr/local/lib/python3.11/site-packages/* \
         /var/lib/apt/lists/* \
         /tmp/408d7c34-observation-history-fk-race.patch \
+        /tmp/conditional-entity-aliases.patch \
     && rm -f \
         /usr/bin/npm \
         /usr/bin/npx \

--- a/memory/compose.yml
+++ b/memory/compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile.hindsight
       args:
         HINDSIGHT_CONTROL_PLANE_IMAGE: ${HINDSIGHT_CONTROL_PLANE_IMAGE:-telefire-hindsight-control-plane:0.8.4-bank-name.1}
-    image: telefire-hindsight:0.8.4-bank-name.1-hardened-r1
+    image: telefire-hindsight:0.8.4-bank-name.1-hardened-r2
     container_name: memory-api
     # pg0 uses 512 MB maintenance_work_mem while creating vector indexes.
     shm_size: 1gb

--- a/memory/patches/conditional-entity-aliases.patch
+++ b/memory/patches/conditional-entity-aliases.patch
@@ -1,0 +1,59 @@
+diff --git a/hindsight_api/api/http.py b/hindsight_api/api/http.py
+index ca12c4c..6712f7c 100644
+--- a/hindsight_api/api/http.py
++++ b/hindsight_api/api/http.py
+@@ -580,0 +581,4 @@ class EntityInput(BaseModel):
++    match_aliases: list[str] | None = Field(
++        default=None,
++        description="If set, associate this entity only with facts that contain one of these extracted entity names.",
++    )
+@@ -6734 +6738,6 @@ def _register_routes(app: FastAPI):
+-                    content_dict["entities"] = [{"text": e.text, "type": e.type or "CONCEPT"} for e in item.entities]
++                    content_dict["entities"] = []
++                    for entity in item.entities:
++                        serialized_entity = {"text": entity.text, "type": entity.type or "CONCEPT"}
++                        if entity.match_aliases is not None:
++                            serialized_entity["match_aliases"] = entity.match_aliases
++                        content_dict["entities"].append(serialized_entity)
+diff --git a/hindsight_api/engine/retain/entity_processing.py b/hindsight_api/engine/retain/entity_processing.py
+index c89aca0..24004be 100644
+--- a/hindsight_api/engine/retain/entity_processing.py
++++ b/hindsight_api/engine/retain/entity_processing.py
+@@ -7,0 +8 @@ import logging
++import unicodedata
+@@ -14,0 +16,4 @@ logger = logging.getLogger(__name__)
++def _normalize_entity_name(value: str) -> str:
++    return " ".join(unicodedata.normalize("NFKC", value).casefold().split())
++
++
+@@ -36 +41,2 @@ def _prepare_facts_for_entity_processing(
+-        seen_texts = {e["text"].lower() for e in llm_entities}
++        fact_entity_names = {_normalize_entity_name(entity["text"]) for entity in llm_entities}
++        seen_texts = set(fact_entity_names)
+@@ -38 +44,10 @@ def _prepare_facts_for_entity_processing(
+-            if user_entity["text"].lower() not in seen_texts:
++            match_aliases = user_entity.get("match_aliases")
++            if match_aliases is not None:
++                normalized_aliases = {
++                    _normalize_entity_name(alias) for alias in match_aliases if isinstance(alias, str) and alias.strip()
++                }
++                if not fact_entity_names.intersection(normalized_aliases):
++                    continue
++
++            normalized_text = _normalize_entity_name(user_entity["text"])
++            if normalized_text not in seen_texts:
+@@ -45 +60 @@ def _prepare_facts_for_entity_processing(
+-                seen_texts.add(user_entity["text"].lower())
++                seen_texts.add(normalized_text)
+diff --git a/hindsight_api/engine/retain/types.py b/hindsight_api/engine/retain/types.py
+index 271e82e..70aa7cc 100644
+--- a/hindsight_api/engine/retain/types.py
++++ b/hindsight_api/engine/retain/types.py
+@@ -40 +40 @@ class RetainContentDict(TypedDict, total=False):
+-    entities: list[dict[str, str]]  # [{"text": "...", "type": "..."}]
++    entities: list[dict[str, str | list[str]]]  # text, type, and optional match_aliases
+@@ -60 +60,3 @@ class RetainContent:
+-    entities: list[dict[str, str]] = field(default_factory=list)  # User-provided entities
++    entities: list[dict[str, str | list[str]]] = field(
++        default_factory=list
++    )  # User-provided entities with optional match aliases

--- a/src/telefire/ai_memory.py
+++ b/src/telefire/ai_memory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import unicodedata
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, Literal, Protocol
@@ -24,6 +25,10 @@ from telefire.memory_directory import (
 
 
 MemoryUpdateMode = Literal["replace", "append"]
+
+
+def _normalize_entity_alias(value: str) -> str:
+    return " ".join(unicodedata.normalize("NFKC", value).casefold().split())
 
 
 @dataclass(frozen=True, slots=True)
@@ -119,16 +124,41 @@ class MemoryEpisode:
         return tuple(actors)
 
     @property
-    def document_entity_ids(self) -> tuple[str, ...]:
-        # Hindsight associates top-level entities with every fact from a document.
-        if len(self.events) != 1:
-            return ()
-        event = self.events[0]
-        return tuple(
-            dict.fromkeys(
-                (event.actor_id, *(actor_id for actor_id, _ in event.mentioned_actors))
+    def fact_entity_hints(
+        self,
+    ) -> tuple[tuple[str, tuple[str, ...] | None], ...]:
+        if len(self.events) == 1:
+            return tuple((actor_id, None) for actor_id in self.actor_ids)
+
+        aliases_by_actor: dict[str, dict[str, str]] = {}
+
+        def add_actor(actor_id: str, display_name: str | None) -> None:
+            aliases = aliases_by_actor.setdefault(actor_id, {})
+            if display_name:
+                normalized = _normalize_entity_alias(display_name)
+                if normalized:
+                    aliases.setdefault(normalized, display_name)
+
+        for event in self.events:
+            add_actor(event.actor_id, event.actor_display_name)
+            for actor_id, display_name in event.mentioned_actors:
+                add_actor(actor_id, display_name)
+
+        alias_owners: dict[str, set[str]] = {}
+        for actor_id, aliases in aliases_by_actor.items():
+            for normalized in aliases:
+                alias_owners.setdefault(normalized, set()).add(actor_id)
+
+        hints = []
+        for actor_id, aliases in aliases_by_actor.items():
+            unique_aliases = tuple(
+                display_name
+                for normalized, display_name in aliases.items()
+                if alias_owners[normalized] == {actor_id}
             )
-        )
+            if unique_aliases:
+                hints.append((actor_id, unique_aliases))
+        return tuple(hints)
 
     @property
     def event_versions(self) -> tuple[tuple[str, str], ...]:
@@ -730,6 +760,12 @@ class HindsightMemoryClient:
         latest = episode.events[-1].occurred_at
         if latest.tzinfo is None:
             latest = latest.replace(tzinfo=UTC)
+        entities: list[dict[str, Any]] = []
+        for actor_id, match_aliases in episode.fact_entity_hints:
+            entity: dict[str, Any] = {"text": actor_id, "type": "PERSON"}
+            if match_aliases is not None:
+                entity["match_aliases"] = list(match_aliases)
+            entities.append(entity)
         return {
             "content": episode.content,
             "context": cls._episode_context(episode),
@@ -742,10 +778,7 @@ class HindsightMemoryClient:
                 "scope_id": episode.scope_id,
                 "content_hash": episode.content_hash,
             },
-            "entities": [
-                {"text": actor_id, "type": "PERSON"}
-                for actor_id in episode.document_entity_ids
-            ],
+            "entities": entities,
         }
 
     @staticmethod

--- a/tests/test_ai_memory_client.py
+++ b/tests/test_ai_memory_client.py
@@ -52,17 +52,37 @@ def episode() -> MemoryEpisode:
     )
 
 
-def test_document_entities_only_cover_a_single_event():
+def test_fact_entity_hints_are_conditional_for_multiple_events():
     item = episode()
 
     assert item.actor_ids == ("telegram:user:10", "telegram:user:20")
-    assert item.document_entity_ids == ()
+    assert item.fact_entity_hints == (
+        ("telegram:user:10", ("Alice Example",)),
+        ("telegram:user:20", ("Bob Example",)),
+    )
 
     single_event = replace(item, events=(item.events[1],))
-    assert single_event.document_entity_ids == (
-        "telegram:user:20",
-        "telegram:user:10",
+    assert single_event.fact_entity_hints == (
+        ("telegram:user:20", None),
+        ("telegram:user:10", None),
     )
+
+
+def test_fact_entity_hints_omit_ambiguous_display_names():
+    item = episode()
+    ambiguous = replace(
+        item,
+        events=(
+            replace(item.events[0], actor_display_name="Alex"),
+            replace(
+                item.events[1],
+                actor_display_name="Alex",
+                mentioned_actors=(),
+            ),
+        ),
+    )
+
+    assert ambiguous.fact_entity_hints == ()
 
 
 async def start_server(configure):
@@ -151,7 +171,18 @@ async def test_hindsight_client_retains_episode_and_renders_bank_recall():
         assert request_item["document_id"] == item.document_id
         assert request_item["update_mode"] == "replace"
         assert request_item["metadata"]["content_hash"] == item.content_hash
-        assert request_item["entities"] == []
+        assert request_item["entities"] == [
+            {
+                "text": "telegram:user:10",
+                "type": "PERSON",
+                "match_aliases": ["Alice Example"],
+            },
+            {
+                "text": "telegram:user:20",
+                "type": "PERSON",
+                "match_aliases": ["Bob Example"],
+            },
+        ]
         retained_content = json.loads(request_item["content"])
         assert retained_content["schema"] == "telefire.memory.episode.v1"
         assert retained_content["events"][1]["actor"] == {


### PR DESCRIPTION
## Summary
- send canonical actor IDs as conditional entity hints for multi-message episodes
- attach each ID only when a fact contains that actor's unique display-name alias
- fail closed for ambiguous aliases while preserving legacy single-event behavior
- ship the Hindsight extension in the pinned local image with no extra model or database calls

## Verification
- full repository suite: 332 passed, 8 skipped
- focused memory client suite: 10 passed
- rebuilt the pinned Hindsight image from the committed patch
- direct resolver test kept Alice/Bob IDs on their own facts only
- resolver microbenchmark: about 0.48 ms per 30-fact document